### PR TITLE
Add Chromium 92.0.4515.159 licenses

### DIFF
--- a/chromium-licenses/third_party/libjpeg_turbo/LICENSE.md
+++ b/chromium-licenses/third_party/libjpeg_turbo/LICENSE.md
@@ -91,7 +91,7 @@ best of our understanding.
 The Modified (3-clause) BSD License
 ===================================
 
-Copyright (C)2009-2020 D. R. Commander.  All Rights Reserved.
+Copyright (C)2009-2021 D. R. Commander.  All Rights Reserved.<br>
 Copyright (C)2015 Viktor Szathmáry.  All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
We have upgraded Chromium to version 92.0.4515.159. Please analyze the diff of the Chromium open source component licenses used in this new version and update all the required documents.