### PR TITLE
Force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.txt           text
+*.md            text
+*.v8            text
+*.html          text
+*.fdlibm        text
+*.chromium      text
+*.strongtalk    text
+LICENSE         text


### PR DESCRIPTION
In this changeset, we force UNIX line-ending on the repository level to keep the differences between license concise.