### PR TITLE
Update Chromium to version 139.0.7258.67

### DIFF
--- a/chromium-licenses.spdx.json
+++ b/chromium-licenses.spdx.json
@@ -1,7 +1,7 @@
 {
     "SPDXID": "SPDXRef-DOCUMENT",
     "creationInfo": {
-        "created": "2025-07-30T21:30:00Z",
+        "created": "2025-08-06T13:33:10Z",
         "creators": [
             "Tool: spdx.py"
         ]
@@ -169,11 +169,6 @@
             "name": "MIT, NCSA"
         },
         {
-            "extractedText": "The Mesa header files use the following licenses.\n\n================================================================================\n\nThe default Mesa license is as follows:\n\nCopyright (C) 1999-2007  Brian Paul   All Rights Reserved.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the \"Software\"),\nto deal in the Software without restriction, including without limitation\nthe rights to use, copy, modify, merge, publish, distribute, sublicense,\nand/or sell copies of the Software, and to permit persons to whom the\nSoftware is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL\nBRIAN PAUL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN\nAN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN\nCONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n\n================================================================================\n\nGLES/glext.h, GLES/gl.h and GLES/glplatform.h use the following license:\n\nSGI FREE SOFTWARE LICENSE B\n(Version 2.0, Sept. 18, 2008)\n\nCopyright (C) [dates of first publication] Silicon Graphics, Inc. All Rights Reserved.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice including the dates of first publication and either this permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL SILICON GRAPHICS, INC. BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n\nExcept as contained in this notice, the name of Silicon Graphics, Inc. shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from Silicon Graphics, Inc.\n\n",
-            "licenseId": "LicenseRef-third-party-mesa-headers-license",
-            "name": "MIT, SGI-B-2.0"
-        },
-        {
             "extractedText": "Copyright 2001-2023 Xiph.Org, Skype Limited, Octasic,\n                    Jean-Marc Valin, Timothy B. Terriberry,\n                    CSIRO, Gregory Maxwell, Mark Borgerding,\n                    Erik de Castro Lopo, Mozilla, Amazon\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n- Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n\n- Redistributions in binary form must reproduce the above copyright\nnotice, this list of conditions and the following disclaimer in the\ndocumentation and/or other materials provided with the distribution.\n\n- Neither the name of Internet Society, IETF or IETF Trust, nor the\nnames of specific contributors, may be used to endorse or promote\nproducts derived from this software without specific prior written\npermission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER\nOR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\nPROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR\nPROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF\nLIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\nNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\nOpus is subject to the royalty-free patent licenses which are\nspecified at:\n\nXiph.Org Foundation:\nhttps://datatracker.ietf.org/ipr/1524/\n\nMicrosoft Corporation:\nhttps://datatracker.ietf.org/ipr/1914/\n\nBroadcom Corporation:\nhttps://datatracker.ietf.org/ipr/1526/\n",
             "licenseId": "LicenseRef-third-party-opus-src-copying",
             "name": "Opus-Patent-BSD-3-Clause"
@@ -336,7 +331,7 @@
     ],
     "name": "Chromium-licenses",
     "spdxVersion": "SPDX-2.3",
-    "documentNamespace": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/",
+    "documentNamespace": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/",
     "packages": [
         {
             "SPDXID": "SPDXRef-Package-CityHash",
@@ -344,7 +339,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/cityhash/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/cityhash/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -358,7 +353,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/cityhash_v103/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/cityhash_v103/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -372,7 +367,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/double_conversion/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/double_conversion/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -386,7 +381,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/nspr/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/nspr/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -400,7 +395,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/superfasthash/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/superfasthash/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -414,7 +409,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/symbolize/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/symbolize/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -428,7 +423,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/base/third_party/xdg_user_dirs/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/base/third_party/xdg_user_dirs/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -438,25 +433,11 @@
         },
         {
             "SPDXID": "SPDXRef-Package-Mozilla-Personal-Security-Manager",
-            "downloadLocation": "https://hg.mozilla.org/mozilla-central/",
-            "externalRefs": [
-                {
-                    "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/chrome/third_party/mozilla_security_manager/LICENSE",
-                    "referenceType": "url"
-                }
-            ],
-            "filesAnalyzed": true,
-            "licenseConcluded": "MPL-1.1",
-            "name": "Mozilla Personal Security Manager"
-        },
-        {
-            "SPDXID": "SPDXRef-Package-Mozilla-Personal-Security-Manager-1",
             "downloadLocation": "https://dxr.mozilla.org/mozilla1.9.2/source/security/manager/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/net/third_party/mozilla_security_manager/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/net/third_party/mozilla_security_manager/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -470,7 +451,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/net/third_party/mozilla_win/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/net/third_party/mozilla_win/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -484,7 +465,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/net/third_party/nss/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/net/third_party/nss/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -498,7 +479,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/net/third_party/quiche/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/net/third_party/quiche/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -512,7 +493,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/net/third_party/uri_template/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/net/third_party/uri_template/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -526,7 +507,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/abseil-cpp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/abseil-cpp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -540,7 +521,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/angle/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/angle/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -556,7 +537,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/angle/src/common/third_party/xxhash/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/angle/src/common/third_party/xxhash/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -570,7 +551,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/angle/src/third_party/libXNVCtrl/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/angle/src/third_party/libXNVCtrl/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -584,7 +565,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/angle/src/third_party/volk/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/angle/src/third_party/volk/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -598,7 +579,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/anonymous_tokens/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/anonymous_tokens/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -612,7 +593,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/blink/LICENSE_FOR_ABOUT_CREDITS",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/blink/LICENSE_FOR_ABOUT_CREDITS",
                     "referenceType": "url"
                 }
             ],
@@ -628,7 +609,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/boringssl/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/boringssl/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -644,7 +625,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/boringssl/src/third_party/fiat/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/boringssl/src/third_party/fiat/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -658,7 +639,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/brotli/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/brotli/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -672,7 +653,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ced/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ced/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -686,7 +667,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/cld_3/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/cld_3/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -700,7 +681,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/compiler-rt/src/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/compiler-rt/src/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -716,7 +697,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/content_analysis_sdk/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/content_analysis_sdk/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -730,7 +711,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/coremltools/mlmodel/format/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/coremltools/mlmodel/format/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -744,7 +725,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/cpuinfo/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/cpuinfo/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -758,7 +739,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/crabbyavif/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/crabbyavif/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -772,7 +753,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/crashpad/crashpad/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/crashpad/crashpad/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -786,7 +767,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/crashpad/crashpad/third_party/getopt/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/crashpad/crashpad/third_party/getopt/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -802,7 +783,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/lss/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/lss/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -818,7 +799,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/crc32c/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/crc32c/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -832,7 +813,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/d3/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/d3/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -846,7 +827,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dav1d/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dav1d/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -860,7 +841,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dawn/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dawn/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -874,7 +855,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dawn/third_party/dxc/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dawn/third_party/dxc/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -890,7 +871,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dawn/third_party/khronos/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dawn/third_party/khronos/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -904,7 +885,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/decklink/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/decklink/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -918,7 +899,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -932,7 +913,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/acorn/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/acorn/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -946,7 +927,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -960,7 +941,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror.next/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror.next/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -974,7 +955,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/csp_evaluator/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/csp_evaluator/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -988,7 +969,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/diff/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/diff/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1002,7 +983,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/i18n/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/i18n/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1016,7 +997,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/intl-messageformat/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/intl-messageformat/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1030,7 +1011,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/json5/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/json5/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1044,7 +1025,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/legacy-javascript/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/legacy-javascript/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1060,7 +1041,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lighthouse/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lighthouse/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1074,7 +1055,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lit/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lit/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1088,7 +1069,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/marked/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/marked/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1104,7 +1085,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1118,7 +1099,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer-replay/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer-replay/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1132,7 +1113,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/mitt/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/mitt/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1146,7 +1127,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/parsel/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/parsel/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1160,7 +1141,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/rxjs/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/rxjs/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1174,7 +1155,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/third-party-web/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/third-party-web/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1188,7 +1169,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/vscode.web-custom-data/package/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/vscode.web-custom-data/package/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -1202,7 +1183,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/wasmparser/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/wasmparser/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1216,7 +1197,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/web-vitals/package/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/web-vitals/package/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1230,7 +1211,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dom_distiller_js/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dom_distiller_js/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1246,12 +1227,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dragonbox/src/LICENSE-Apache2-LLVM",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dragonbox/src/LICENSE-Apache2-LLVM",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/dragonbox/src/LICENSE-Boost",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/dragonbox/src/LICENSE-Boost",
                     "referenceType": "url"
                 }
             ],
@@ -1268,7 +1249,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/emoji-segmenter/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/emoji-segmenter/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1282,7 +1263,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/expat/src/expat/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/expat/src/expat/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -1296,7 +1277,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/farmhash/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/farmhash/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1310,7 +1291,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fast_float/src/LICENSE-MIT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fast_float/src/LICENSE-MIT",
                     "referenceType": "url"
                 }
             ],
@@ -1324,7 +1305,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fdlibm/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fdlibm/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1338,7 +1319,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ffmpeg/CREDITS.chromium",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ffmpeg/CREDITS.chromium",
                     "referenceType": "url"
                 }
             ],
@@ -1352,7 +1333,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fft2d/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fft2d/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1368,7 +1349,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/flac/COPYING.Xiph",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/flac/COPYING.Xiph",
                     "referenceType": "url"
                 }
             ],
@@ -1384,7 +1365,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/flatbuffers/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/flatbuffers/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1398,7 +1379,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fontconfig/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fontconfig/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -1414,7 +1395,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fp16/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fp16/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1428,7 +1409,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/freetype/src/docs/FTL.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/freetype/src/docs/FTL.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -1442,7 +1423,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/fxdiv/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/fxdiv/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1456,7 +1437,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/gemmlowp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/gemmlowp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1470,7 +1451,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/google_toolbox_for_mac/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/google_toolbox_for_mac/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1484,7 +1465,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/harfbuzz-ng/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/harfbuzz-ng/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -1498,7 +1479,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/highway/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/highway/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1512,7 +1493,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/hunspell/COPYING.MPL",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/hunspell/COPYING.MPL",
                     "referenceType": "url"
                 }
             ],
@@ -1526,7 +1507,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/iaccessible2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/iaccessible2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1542,7 +1523,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/icu/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/icu/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1556,7 +1537,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ink/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ink/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1570,7 +1551,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ink_stroke_modeler/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ink_stroke_modeler/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1584,7 +1565,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/inspector_protocol/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/inspector_protocol/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1598,7 +1579,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ipcz/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ipcz/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1614,7 +1595,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/isimpledom/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/isimpledom/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1628,7 +1609,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/jsoncpp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/jsoncpp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1644,7 +1625,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/lens_server_proto/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/lens_server_proto/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1658,7 +1639,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/leveldatabase/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/leveldatabase/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1672,7 +1653,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaddressinput/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaddressinput/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1686,12 +1667,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaom/source/libaom/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaom/source/libaom/LICENSE",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaom/source/libaom/PATENTS",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaom/source/libaom/PATENTS",
                     "referenceType": "url"
                 }
             ],
@@ -1708,7 +1689,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaom/source/libaom/third_party/SVT-AV1/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaom/source/libaom/third_party/SVT-AV1/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -1722,7 +1703,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaom/source/libaom/third_party/fastfeat/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaom/source/libaom/third_party/fastfeat/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1738,7 +1719,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libaom/source/libaom/third_party/vector/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libaom/source/libaom/third_party/vector/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1752,7 +1733,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libc++/src/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libc++/src/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -1768,7 +1749,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libc++abi/src/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libc++abi/src/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -1784,7 +1765,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libgav1/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libgav1/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1798,7 +1779,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libjpeg_turbo/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libjpeg_turbo/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -1814,7 +1795,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libphonenumber/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libphonenumber/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1828,7 +1809,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libpng/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libpng/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1844,7 +1825,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libsecret/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libsecret/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1858,7 +1839,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libsrtp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libsrtp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1872,7 +1853,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libsync/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libsync/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1886,7 +1867,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libtess2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libtess2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1900,7 +1881,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/liburlpattern/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/liburlpattern/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -1914,7 +1895,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libusb/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libusb/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -1928,12 +1909,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libvpx/source/libvpx/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libvpx/source/libvpx/LICENSE",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libvpx/source/libvpx/PATENTS",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libvpx/source/libvpx/PATENTS",
                     "referenceType": "url"
                 }
             ],
@@ -1950,12 +1931,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libwebm/source/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libwebm/source/LICENSE.TXT",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libwebm/source/PATENTS.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libwebm/source/PATENTS.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -1972,12 +1953,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libwebp/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libwebp/src/COPYING",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libwebp/src/PATENTS",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libwebp/src/PATENTS",
                     "referenceType": "url"
                 }
             ],
@@ -1994,17 +1975,17 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libxml/src/Copyright",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libxml/src/Copyright",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libxml/src/dict.c",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libxml/src/dict.c",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libxml/src/list.c",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libxml/src/list.c",
                     "referenceType": "url"
                 }
             ],
@@ -2018,7 +1999,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libxslt/src/Copyright",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libxslt/src/Copyright",
                     "referenceType": "url"
                 }
             ],
@@ -2032,7 +2013,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libyuv/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libyuv/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2046,7 +2027,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/libzip/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/libzip/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2060,7 +2041,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/lit/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/lit/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2074,7 +2055,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/llvm-libc/src/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/llvm-libc/src/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -2090,7 +2071,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/lottie/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/lottie/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2104,7 +2085,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/lzma_sdk/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/lzma_sdk/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2118,7 +2099,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/material_color_utilities/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/material_color_utilities/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2127,28 +2108,12 @@
             "name": "Material color utilities"
         },
         {
-            "SPDXID": "SPDXRef-Package-mesa-headers",
-            "downloadLocation": "https://gitlab.freedesktop.org/mesa/mesa",
-            "externalRefs": [
-                {
-                    "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/mesa_headers/LICENSE",
-                    "referenceType": "url"
-                }
-            ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-mesa-headers-license"
-            ],
-            "name": "mesa_headers"
-        },
-        {
             "SPDXID": "SPDXRef-Package-Metrics-Protos",
             "downloadLocation": "NONE",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/metrics_proto/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/metrics_proto/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2162,7 +2127,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/microsoft_webauthn/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/microsoft_webauthn/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2176,7 +2141,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/minigbm/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/minigbm/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2190,7 +2155,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/modp_b64/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/modp_b64/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2204,7 +2169,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/neon_2_sse/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/neon_2_sse/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2218,7 +2183,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/node/node_modules/lit/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/node/node_modules/lit/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2232,7 +2197,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
                 }
             ],
@@ -2246,7 +2211,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/node/node_modules/@azure/msal-browser/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/node/node_modules/@azure/msal-browser/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2260,7 +2225,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
                 }
             ],
@@ -2274,7 +2239,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
                 }
             ],
@@ -2288,7 +2253,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/omnibox_proto/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/omnibox_proto/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2302,7 +2267,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/one_euro_filter/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/one_euro_filter/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2316,7 +2281,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/openh264/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/openh264/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2330,7 +2295,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/openscreen/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/openscreen/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2344,7 +2309,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/abseil-cpp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/abseil-cpp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2358,7 +2323,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/boringssl/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/boringssl/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2374,7 +2339,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/jsoncpp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/jsoncpp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2388,7 +2353,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/openxr/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/openxr/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2402,7 +2367,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/openxr/src/src/external/jnipp/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/openxr/src/src/external/jnipp/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2416,7 +2381,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/openxr/src/LICENSES/Apache-2.0.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/openxr/src/LICENSES/Apache-2.0.txt",
                     "referenceType": "url"
                 }
             ],
@@ -2430,7 +2395,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/opus/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/opus/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -2446,7 +2411,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ots/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ots/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2460,7 +2425,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pdfium/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pdfium/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2476,7 +2441,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pdfium/third_party/agg23/copying",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pdfium/third_party/agg23/copying",
                     "referenceType": "url"
                 }
             ],
@@ -2490,7 +2455,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pdfium/third_party/bigint/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pdfium/third_party/bigint/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2506,7 +2471,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pdfium/third_party/libopenjpeg/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pdfium/third_party/libopenjpeg/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2520,7 +2485,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pdfium/third_party/libtiff/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pdfium/third_party/libtiff/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -2536,7 +2501,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/perfetto/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/perfetto/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2552,7 +2517,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pffft/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pffft/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2568,7 +2533,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/polymer/LICENSE.polymer",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/polymer/LICENSE.polymer",
                     "referenceType": "url"
                 }
             ],
@@ -2582,7 +2547,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/private-join-and-compute/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/private-join-and-compute/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2596,7 +2561,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/private_membership/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/private_membership/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2610,7 +2575,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/protobuf/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/protobuf/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2624,7 +2589,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/protobuf-javascript/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/protobuf-javascript/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2638,7 +2603,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/protobuf/third_party/utf8_range/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/protobuf/third_party/utf8_range/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2652,7 +2617,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/pthreadpool/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/pthreadpool/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2666,7 +2631,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/puffin/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/puffin/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2680,7 +2645,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/re2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/re2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2694,7 +2659,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rnnoise/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rnnoise/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -2708,7 +2673,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/adler2-v2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/adler2-v2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2722,7 +2687,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/anyhow-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/anyhow-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2736,7 +2701,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bitflags-v2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bitflags-v2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2750,7 +2715,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2764,7 +2729,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck_derive-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck_derive-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2773,12 +2738,26 @@
             "name": "bytemuck_derive"
         },
         {
+            "SPDXID": "SPDXRef-Package-bytes",
+            "downloadLocation": "https://crates.io/crates/bytes",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytes-v1/LICENSE",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": true,
+            "licenseConcluded": "MIT",
+            "name": "bytes"
+        },
+        {
             "SPDXID": "SPDXRef-Package-calendrical-calculations",
             "downloadLocation": "https://crates.io/crates/calendrical_calculations",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/calendrical_calculations-v0_2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/calendrical_calculations-v0_2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2792,7 +2771,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cfg-if-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cfg-if-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2801,12 +2780,26 @@
             "name": "cfg-if"
         },
         {
+            "SPDXID": "SPDXRef-Package-combine",
+            "downloadLocation": "https://crates.io/crates/combine",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/combine-v4/LICENSE",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": true,
+            "licenseConcluded": "MIT",
+            "name": "combine"
+        },
+        {
             "SPDXID": "SPDXRef-Package-core-maths",
             "downloadLocation": "https://crates.io/crates/core_maths",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/core_maths-v0_1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/core_maths-v0_1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2820,7 +2813,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/crc32fast-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/crc32fast-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2834,7 +2827,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxx-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxx-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2848,7 +2841,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxxbridge-macro-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxxbridge-macro-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2862,7 +2855,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/derivre-v0_3/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/derivre-v0_3/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -2876,7 +2869,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-v0_11/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-v0_12/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2890,7 +2883,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat_core-v0_11/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat_core-v0_12/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2904,7 +2897,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-runtime-v0_11/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-runtime-v0_12/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2918,7 +2911,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/displaydoc-v0_2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/displaydoc-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2932,7 +2925,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/either-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/either-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2946,7 +2939,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/equivalent-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/equivalent-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2960,7 +2953,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/fdeflate-v0_3/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/fdeflate-v0_3/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2974,7 +2967,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/flate2-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/flate2-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -2988,7 +2981,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/foldhash-v0_1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/foldhash-v0_1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3002,7 +2995,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/font-types-v0_8/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/font-types-v0_9/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3016,7 +3009,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/hashbrown-v0_15/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/hashbrown-v0_15/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3030,7 +3023,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/heck-v0_5/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/heck-v0_5/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3044,7 +3037,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3058,7 +3051,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar_data-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar_data-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3072,7 +3065,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_collections-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_collections-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3086,7 +3079,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3100,7 +3093,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_core-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_core-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3114,7 +3107,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_data-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_data-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3128,7 +3121,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_provider-v2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_provider-v2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3142,7 +3135,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/indexmap-v2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/indexmap-v2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3156,7 +3149,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/itoa-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/itoa-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3170,7 +3163,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ixdtf-v0_5/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ixdtf-v0_5/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3179,12 +3172,26 @@
             "name": "ixdtf"
         },
         {
+            "SPDXID": "SPDXRef-Package-jiff-tzdb",
+            "downloadLocation": "https://crates.io/crates/jiff-tzdb",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/jiff-tzdb-v0_1/LICENSE-MIT",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": true,
+            "licenseConcluded": "MIT",
+            "name": "jiff-tzdb"
+        },
+        {
             "SPDXID": "SPDXRef-Package-libc",
             "downloadLocation": "https://crates.io/crates/libc",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libc-v0_2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libc-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3198,7 +3205,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libm-v0_2/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libm-v0_2/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -3212,7 +3219,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/litemap-v0_8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/litemap-v0_8/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3226,7 +3233,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/llguidance-v0_7/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/llguidance-v0_7/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3240,7 +3247,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/log-v0_4/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/log-v0_4/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3254,7 +3261,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/memchr-v2/LICENSE-MIT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/memchr-v2/LICENSE-MIT",
                     "referenceType": "url"
                 }
             ],
@@ -3268,7 +3275,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/miniz_oxide-v0_8/LICENSE-APACHE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/miniz_oxide-v0_8/LICENSE-APACHE.md",
                     "referenceType": "url"
                 }
             ],
@@ -3282,7 +3289,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/num-traits-v0_2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/num-traits-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3296,7 +3303,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/png-v0_18/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/png-v0_18/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3310,7 +3317,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/potential_utf-v0_1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/potential_utf-v0_1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3324,7 +3331,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/proc-macro2-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/proc-macro2-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3338,7 +3345,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/qr_code-v2/LICENSE-APACHE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/qr_code-v2/LICENSE-APACHE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -3352,7 +3359,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/quote-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/quote-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3366,7 +3373,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/read-fonts-v0_27/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/read-fonts-v0_30/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3380,7 +3387,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/regex-syntax-v0_8/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/regex-syntax-v0_8/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3394,7 +3401,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/rustversion-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/rustversion-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3408,7 +3415,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ryu-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ryu-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3422,7 +3429,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3436,7 +3443,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_derive-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_derive-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3450,7 +3457,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3464,7 +3471,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json_lenient-v0_2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json_lenient-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3478,7 +3485,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/simd-adler32-v0_3/LICENSE.md",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/simd-adler32-v0_3/LICENSE.md",
                     "referenceType": "url"
                 }
             ],
@@ -3492,7 +3499,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/skrifa-v0_29/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/skrifa-v0_32/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3506,7 +3513,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/smallvec-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/smallvec-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3520,7 +3527,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/stable_deref_trait-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/stable_deref_trait-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3534,7 +3541,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strck-v1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strck-v1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3548,7 +3555,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum-v0_27/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum-v0_27/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3562,7 +3569,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum_macros-v0_27/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum_macros-v0_27/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3576,7 +3583,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/syn-v2/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/syn-v2/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3590,7 +3597,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/synstructure-v0_13/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/synstructure-v0_13/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3604,12 +3611,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_capi-v0_0/LICENSE-MIT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_capi-v0_0_9/LICENSE-MIT",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_capi-v0_0/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_capi-v0_0_9/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3623,12 +3630,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_rs-v0_0/LICENSE-MIT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_rs-v0_0_9/LICENSE-MIT",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_rs-v0_0/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_rs-v0_0_9/LICENSE-APACHE",
                     "referenceType": "url"
                 }
             ],
@@ -3637,12 +3644,31 @@
             "name": "temporal_rs"
         },
         {
+            "SPDXID": "SPDXRef-Package-timezone-provider",
+            "downloadLocation": "https://crates.io/crates/timezone_provider",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/timezone_provider-v0_0_9/LICENSE-MIT",
+                    "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/timezone_provider-v0_0_9/LICENSE-APACHE",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": true,
+            "licenseConcluded": "Apache-2.0",
+            "name": "timezone_provider"
+        },
+        {
             "SPDXID": "SPDXRef-Package-tinystr",
             "downloadLocation": "https://crates.io/crates/tinystr",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/tinystr-v0_8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/tinystr-v0_8/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3656,7 +3682,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/toktrie-v0_7/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/toktrie-v0_7/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3665,17 +3691,31 @@
             "name": "toktrie"
         },
         {
+            "SPDXID": "SPDXRef-Package-tzif",
+            "downloadLocation": "https://crates.io/crates/tzif",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/tzif-v0_3/LICENSE",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": true,
+            "licenseConcluded": "Unicode-3.0",
+            "name": "tzif"
+        },
+        {
             "SPDXID": "SPDXRef-Package-unicode-ident",
             "downloadLocation": "https://crates.io/crates/unicode-ident",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-ident-v1/LICENSE-APACHE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-ident-v1/LICENSE-APACHE",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-ident-v1/LICENSE-UNICODE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-ident-v1/LICENSE-UNICODE",
                     "referenceType": "url"
                 }
             ],
@@ -3692,7 +3732,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/writeable-v0_6/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/writeable-v0_6/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3706,7 +3746,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-v0_8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-v0_8/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3720,7 +3760,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-derive-v0_8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-derive-v0_8/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3734,7 +3774,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-v0_1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-v0_1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3748,7 +3788,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-derive-v0_1/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-derive-v0_1/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3762,7 +3802,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerotrie-v0_2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerotrie-v0_2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3776,7 +3816,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-v0_11/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-v0_11/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3790,7 +3830,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-derive-v0_11/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-derive-v0_11/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3804,7 +3844,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/ruy/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/ruy/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3818,7 +3858,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3832,7 +3872,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/sentencepiece/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/sentencepiece/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3848,7 +3888,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/shell-encryption/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/shell-encryption/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3862,7 +3902,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/simdutf/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/simdutf/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3876,7 +3916,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/skia/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/skia/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3890,7 +3930,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/smhasher/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/smhasher/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3906,7 +3946,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/snappy/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/snappy/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -3922,7 +3962,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/speech-dispatcher/COPYING.LGPL",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/speech-dispatcher/COPYING.LGPL",
                     "referenceType": "url"
                 }
             ],
@@ -3936,7 +3976,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/spirv-headers/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/spirv-headers/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3950,7 +3990,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/spirv-tools/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/spirv-tools/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3964,7 +4004,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/sqlite/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/sqlite/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -3978,7 +4018,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -3994,7 +4034,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Headers/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Headers/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4008,7 +4048,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Tools/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Tools/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4022,7 +4062,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/astc-encoder/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/astc-encoder/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4036,7 +4076,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/llvm-10.0/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/llvm-10.0/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4050,7 +4090,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/llvm-subzero/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/llvm-subzero/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -4066,7 +4106,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/marl/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/marl/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4080,7 +4120,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/swiftshader/third_party/subzero/LICENSE.TXT",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/swiftshader/third_party/subzero/LICENSE.TXT",
                     "referenceType": "url"
                 }
             ],
@@ -4096,7 +4136,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/tensorflow-text/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/tensorflow-text/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4110,7 +4150,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/tensorflow_models/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/tensorflow_models/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4124,7 +4164,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/tflite/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/tflite/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4140,7 +4180,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/tflite/src/third_party/xla/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/tflite/src/third_party/xla/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4154,7 +4194,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/tflite_support/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/tflite_support/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4168,7 +4208,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/unrar/src/license.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/unrar/src/license.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4184,7 +4224,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/utf/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/utf/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4200,7 +4240,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/vulkan-headers/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/vulkan-headers/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4214,7 +4254,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/vulkan-loader/src/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/vulkan-loader/src/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4228,7 +4268,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/vulkan_memory_allocator/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/vulkan_memory_allocator/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4242,7 +4282,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wayland/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wayland/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -4256,7 +4296,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wayland-protocols/src/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wayland-protocols/src/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -4270,7 +4310,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wayland-protocols/gtk/COPYING",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wayland-protocols/gtk/COPYING",
                     "referenceType": "url"
                 }
             ],
@@ -4284,7 +4324,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wayland-protocols/kde/COPYING.LIB",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wayland-protocols/kde/COPYING.LIB",
                     "referenceType": "url"
                 }
             ],
@@ -4298,7 +4338,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4314,7 +4354,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/common_audio/third_party/ooura/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/common_audio/third_party/ooura/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4330,7 +4370,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/common_audio/third_party/spl_sqrt_floor/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/common_audio/third_party/spl_sqrt_floor/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4346,7 +4386,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/modules/third_party/fft/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/modules/third_party/fft/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4362,7 +4402,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/modules/third_party/g711/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/modules/third_party/g711/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4378,7 +4418,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/modules/third_party/g722/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/modules/third_party/g722/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4394,7 +4434,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc/rtc_base/third_party/sigslot/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc/rtc_base/third_party/sigslot/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4410,7 +4450,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/webrtc_overrides/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/webrtc_overrides/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4424,7 +4464,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/woff2/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/woff2/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4438,7 +4478,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wtl/Ms-PL.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wtl/Ms-PL.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4452,7 +4492,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/wuffs/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/wuffs/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4466,7 +4506,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/xdg-utils/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/xdg-utils/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4480,7 +4520,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/xnnpack/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/xnnpack/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4494,7 +4534,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/zlib/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/zlib/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4508,7 +4548,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/zstd/src/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/zstd/src/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4522,7 +4562,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/third_party/zxcvbn-cpp/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/third_party/zxcvbn-cpp/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4536,7 +4576,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/url/third_party/mozilla/LICENSE.txt",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/url/third_party/mozilla/LICENSE.txt",
                     "referenceType": "url"
                 }
             ],
@@ -4550,22 +4590,22 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/LICENSE",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/LICENSE.fdlibm",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/LICENSE.fdlibm",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/LICENSE.strongtalk",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/LICENSE.strongtalk",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/LICENSE.v8",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/LICENSE.v8",
                     "referenceType": "url"
                 }
             ],
@@ -4584,7 +4624,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/rapidhash-v8/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/rapidhash-v8/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4600,7 +4640,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/glibc/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/glibc/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4614,7 +4654,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/inspector_protocol/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/inspector_protocol/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4628,7 +4668,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/siphash/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/siphash/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4644,7 +4684,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/utf8-decoder/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/utf8-decoder/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4658,12 +4698,12 @@
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/v8/builtins/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/v8/builtins/LICENSE",
                     "referenceType": "url"
                 },
                 {
                     "referenceCategory": "OTHER",
-                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v138.0.7204.184/chromium-licenses/v8/third_party/v8/codegen/LICENSE",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v139.0.7258.67/chromium-licenses/v8/third_party/v8/codegen/LICENSE",
                     "referenceType": "url"
                 }
             ],
@@ -4714,11 +4754,6 @@
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-Mozilla-Personal-Security-Manager",
-            "relationshipType": "DESCRIBES"
-        },
-        {
-            "spdxElementId": "SPDXRef-DOCUMENT",
-            "relatedSpdxElement": "SPDXRef-Package-Mozilla-Personal-Security-Manager-1",
             "relationshipType": "DESCRIBES"
         },
         {
@@ -5283,11 +5318,6 @@
         },
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
-            "relatedSpdxElement": "SPDXRef-Package-mesa-headers",
-            "relationshipType": "DESCRIBES"
-        },
-        {
-            "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-Metrics-Protos",
             "relationshipType": "DESCRIBES"
         },
@@ -5508,12 +5538,22 @@
         },
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-bytes",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-calendrical-calculations",
             "relationshipType": "DESCRIBES"
         },
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-cfg-if",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-combine",
             "relationshipType": "DESCRIBES"
         },
         {
@@ -5649,6 +5689,11 @@
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-ixdtf",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-jiff-tzdb",
             "relationshipType": "DESCRIBES"
         },
         {
@@ -5813,12 +5858,22 @@
         },
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-timezone-provider",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-tinystr",
             "relationshipType": "DESCRIBES"
         },
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
             "relatedSpdxElement": "SPDXRef-Package-toktrie",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-tzif",
             "relationshipType": "DESCRIBES"
         },
         {


### PR DESCRIPTION
This changeset updates the SPDX file with the licenses from Chromium 139.0.7258.67.

There are no changes in the license files compared to the [previous](https://github.com/TeamDev-IP/Chromium-Licences/pull/83) beta version.