### PR TITLE
Update the SPDX document

### DIFF
--- a/chromium-licenses.spdx.json
+++ b/chromium-licenses.spdx.json
@@ -1,32 +1,17 @@
 {
     "SPDXID": "SPDXRef-DOCUMENT",
     "creationInfo": {
-        "created": "2026-05-06T10:11:23Z",
+        "created": "2026-05-11T08:10:14Z",
         "creators": [
-            "Tool: spdx.py"
+            "Tool: spdx.py-1.1"
         ]
     },
     "dataLicense": "CC0-1.0",
     "hasExtractedLicensingInfos": [
         {
-            "extractedText": "// Copyright 2018 The ANGLE Project Authors.\n// All rights reserved.\n//\n// Redistribution and use in source and binary forms, with or without\n// modification, are permitted provided that the following conditions\n// are met:\n//\n//     Redistributions of source code must retain the above copyright\n//     notice, this list of conditions and the following disclaimer.\n//\n//     Redistributions in binary form must reproduce the above\n//     copyright notice, this list of conditions and the following\n//     disclaimer in the documentation and/or other materials provided\n//     with the distribution.\n//\n//     Neither the name of TransGaming Inc., Google Inc., 3DLabs Inc.\n//     Ltd., nor the names of their contributors may be used to endorse\n//     or promote products derived from this software without specific\n//     prior written permission.\n//\n// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n// \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS\n// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE\n// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,\n// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,\n// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\n// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT\n// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN\n// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\n// POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-third-party-angle-license",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "(WebKit doesn't distribute an explicit license.  This LICENSE is derived from\nlicense text in the source.)\n\nCopyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,\n2006, 2007 Alexander Kellett, Alexey Proskuryakov, Alex Mathews, Allan\nSandfeld Jensen, Alp Toker, Anders Carlsson, Andrew Wellington, Antti\nKoivisto, Apple Inc., Arthur Langereis, Baron Schwartz, Bjoern Graf,\nBrent Fulgham, Cameron Zwarich, Charles Samuels, Christian Dywan,\nCollabora Ltd., Cyrus Patel, Daniel Molkentin, Dave Maclachlan, David\nSmith, Dawit Alemayehu, Dirk Mueller, Dirk Schulze, Don Gibson, Enrico\nRos, Eric Seidel, Frederik Holljen, Frerich Raabe, Friedmann Kleint,\nGeorge Staikos, Google Inc., Graham Dennis, Harri Porten, Henry Mason,\nHiroyuki Ikezoe, Holger Hans Peter Freyther, IBM, James G. Speth, Jan\nAlonzo, Jean-Loup Gailly, John Reis, Jonas Witt, Jon Shier, Jonas\nWitt, Julien Chaffraix, Justin Haygood, Kevin Ollivier, Kevin Watters,\nKimmo Kinnunen, Kouhei Sutou, Krzysztof Kowalczyk, Lars Knoll, Luca\nBruno, Maks Orlovich, Malte Starostik, Mark Adler, Martin Jones,\nMarvin Decker, Matt Lilek, Michael Emmel, Mitz Pettel, mozilla.org,\nNetscape Communications Corporation, Nicholas Shanks, Nikolas\nZimmermann, Nokia, Oliver Hunt, Opened Hand, Paul Johnston, Peter\nKelly, Pioneer Research Center USA, Rich Moore, Rob Buis, Robin Dunn,\nRonald Tschal\u00e4r, Samuel Weinig, Simon Hausmann, Staikos Computing\nServices Inc., Stefan Schimanski, Symantec Corporation, The Dojo\nFoundation, The Karbon Developers, Thomas Boyer, Tim Copperfield,\nTobias Anton, Torben Weis, Trolltech, University of Cambridge, Vaclav\nSlavik, Waldo Bastian, Xan Lopez, Zack Rusin\n\nThe terms and conditions vary from file to file, but are one of:\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in the\n   documentation and/or other materials provided with the\n   distribution.\n\n*OR*\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer.\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in the\n   documentation and/or other materials provided with the\n   distribution.\n3. Neither the name of Apple Computer, Inc. (\"Apple\") nor the names of\n   its contributors may be used to endorse or promote products derived\n   from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY\nEXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE COMPUTER, INC. OR\nCONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\nPROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR\nPROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY\n\nOF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n\n                  GNU LIBRARY GENERAL PUBLIC LICENSE\n                       Version 2, June 1991\n\n Copyright (C) 1991 Free Software Foundation, Inc.\n 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the library GPL.  It is\n numbered 2 because it goes with version 2 of the ordinary GPL.]\n\n                            Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Library General Public License, applies to some\nspecially designated Free Software Foundation software, and to any\nother libraries whose authors decide to use it.  You can use it for\nyour libraries, too.\n\n  When we speak of free software, we are referring to freedom, not\nprice.  Our General Public Licenses are designed to make sure that you\nhave the freedom to distribute copies of free software (and charge for\nthis service if you wish), that you receive source code or can get it\nif you want it, that you can change the software or use pieces of it\nin new free programs; and that you know you can do these things.\n\n  To protect your rights, we need to make restrictions that forbid\nanyone to deny you these rights or to ask you to surrender the rights.\nThese restrictions translate to certain responsibilities for you if\nyou distribute copies of the library, or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link a program with the library, you must provide\ncomplete object files to the recipients so that they can relink them\nwith the library, after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  Our method of protecting your rights has two steps: (1) copyright\nthe library, and (2) offer you this license which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  Also, for each distributor's protection, we want to make certain\nthat everyone understands that there is no warranty for this free\nlibrary.  If the library is modified by someone else and passed on, we\nwant its recipients to know that what they have is not the original\nversion, so that any problems introduced by others will not reflect on\nthe original authors' reputations.\n\f\n  Finally, any free program is threatened constantly by software\npatents.  We wish to avoid the danger that companies distributing free\nsoftware will individually obtain patent licenses, thus in effect\ntransforming the program into proprietary software.  To prevent this,\nwe have made it clear that any patent must be licensed for everyone's\nfree use or not licensed at all.\n\n  Most GNU software, including some libraries, is covered by the ordinary\nGNU General Public License, which was designed for utility programs.  This\nlicense, the GNU Library General Public License, applies to certain\ndesignated libraries.  This license is quite different from the ordinary\none; be sure to read it in full, and don't assume that anything in it is\nthe same as in the ordinary license.\n\n  The reason we have a separate public license for some libraries is that\nthey blur the distinction we usually make between modifying or adding to a\nprogram and simply using it.  Linking a program with a library, without\nchanging the library, is in some sense simply using the library, and is\nanalogous to running a utility program or application program.  However, in\na textual and legal sense, the linked executable is a combined work, a\nderivative of the original library, and the ordinary General Public License\ntreats it as such.\n\n  Because of this blurred distinction, using the ordinary General\nPublic License for libraries did not effectively promote software\nsharing, because most developers did not use the libraries.  We\nconcluded that weaker conditions might promote sharing better.\n\n  However, unrestricted linking of non-free programs would deprive the\nusers of those programs of all benefit from the free status of the\nlibraries themselves.  This Library General Public License is intended to\npermit developers of non-free programs to use free libraries, while\npreserving your freedom as a user of such programs to change the free\nlibraries that are incorporated in them.  (We have not seen how to achieve\nthis as regards changes in header files, but we have achieved it as regards\nchanges in the actual functions of the Library.)  The hope is that this\nwill lead to faster development of free libraries.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, while the latter only\nworks together with the library.\n\n  Note that it is possible for a library to be covered by the ordinary\nGeneral Public License rather than by this special one.\n\f\n                  GNU LIBRARY GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library which\ncontains a notice placed by the copyright holder or other authorized\nparty saying it may be distributed under the terms of this Library\nGeneral Public License (also called \"this License\").  Each licensee is\naddressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n  \n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\f\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\f\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\f\n  6. As an exception to the Sections above, you may also compile or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    c) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    d) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe source code distributed need not include anything that is normally\ndistributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\f\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties to\nthis License.\n\f\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Library General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\f\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n                            NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n                     END OF TERMS AND CONDITIONS\n\n                  GNU LESSER GENERAL PUBLIC LICENSE\n                       Version 2.1, February 1999\n\n Copyright (C) 1991, 1999 Free Software Foundation, Inc.\n 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the Lesser GPL.  It also counts\n as the successor of the GNU Library Public License, version 2, hence\n the version number 2.1.]\n\n                            Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Lesser General Public License, applies to some\nspecially designated software packages--typically libraries--of the\nFree Software Foundation and other authors who decide to use it.  You\ncan use it too, but we suggest you first think carefully about whether\nthis license or the ordinary General Public License is the better\nstrategy to use in any particular case, based on the explanations below.\n\n  When we speak of free software, we are referring to freedom of use,\nnot price.  Our General Public Licenses are designed to make sure that\nyou have the freedom to distribute copies of free software (and charge\nfor this service if you wish); that you receive source code or can get\nit if you want it; that you can change the software and use pieces of\nit in new free programs; and that you are informed that you can do\nthese things.\n\n  To protect your rights, we need to make restrictions that forbid\ndistributors to deny you these rights or to ask you to surrender these\nrights.  These restrictions translate to certain responsibilities for\nyou if you distribute copies of the library or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link other code with the library, you must provide\ncomplete object files to the recipients, so that they can relink them\nwith the library after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  We protect your rights with a two-step method: (1) we copyright the\nlibrary, and (2) we offer you this license, which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  To protect each distributor, we want to make it very clear that\nthere is no warranty for the free library.  Also, if the library is\nmodified by someone else and passed on, the recipients should know\nthat what they have is not the original version, so that the original\nauthor's reputation will not be affected by problems that might be\nintroduced by others.\n\f\n  Finally, software patents pose a constant threat to the existence of\nany free program.  We wish to make sure that a company cannot\neffectively restrict the users of a free program by obtaining a\nrestrictive license from a patent holder.  Therefore, we insist that\nany patent license obtained for a version of the library must be\nconsistent with the full freedom of use specified in this license.\n\n  Most GNU software, including some libraries, is covered by the\nordinary GNU General Public License.  This license, the GNU Lesser\nGeneral Public License, applies to certain designated libraries, and\nis quite different from the ordinary General Public License.  We use\nthis license for certain libraries in order to permit linking those\nlibraries into non-free programs.\n\n  When a program is linked with a library, whether statically or using\na shared library, the combination of the two is legally speaking a\ncombined work, a derivative of the original library.  The ordinary\nGeneral Public License therefore permits such linking only if the\nentire combination fits its criteria of freedom.  The Lesser General\nPublic License permits more lax criteria for linking other code with\nthe library.\n\n  We call this license the \"Lesser\" General Public License because it\ndoes Less to protect the user's freedom than the ordinary General\nPublic License.  It also provides other free software developers Less\nof an advantage over competing non-free programs.  These disadvantages\nare the reason we use the ordinary General Public License for many\nlibraries.  However, the Lesser license provides advantages in certain\nspecial circumstances.\n\n  For example, on rare occasions, there may be a special need to\nencourage the widest possible use of a certain library, so that it becomes\na de-facto standard.  To achieve this, non-free programs must be\nallowed to use the library.  A more frequent case is that a free\nlibrary does the same job as widely used non-free libraries.  In this\ncase, there is little to gain by limiting the free library to free\nsoftware only, so we use the Lesser General Public License.\n\n  In other cases, permission to use a particular library in non-free\nprograms enables a greater number of people to use a large body of\nfree software.  For example, permission to use the GNU C Library in\nnon-free programs enables many more people to use the whole GNU\noperating system, as well as its variant, the GNU/Linux operating\nsystem.\n\n  Although the Lesser General Public License is Less protective of the\nusers' freedom, it does ensure that the user of a program that is\nlinked with the Library has the freedom and the wherewithal to run\nthat program using a modified version of the Library.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, whereas the latter must\nbe combined with the library in order to run.\n\f\n                  GNU LESSER GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library or other\nprogram which contains a notice placed by the copyright holder or\nother authorized party saying it may be distributed under the terms of\nthis Lesser General Public License (also called \"this License\").\nEach licensee is addressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n\n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\f\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\f\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\f\n  6. As an exception to the Sections above, you may also combine or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Use a suitable shared library mechanism for linking with the\n    Library.  A suitable mechanism is one that (1) uses at run time a\n    copy of the library already present on the user's computer system,\n    rather than copying library functions into the executable, and (2)\n    will operate properly with a modified version of the library, if\n    the user installs one, as long as the modified version is\n    interface-compatible with the version that the work was made with.\n\n    c) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    d) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    e) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe materials to be distributed need not include anything that is\nnormally distributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\f\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties with\nthis License.\n\f\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Lesser General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\f\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n                            NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n                     END OF TERMS AND CONDITIONS\n",
-            "licenseId": "LicenseRef-third-party-blink-license-for-about-credits",
-            "name": "BSD and LGPL v2 and LGPL v2.1"
-        },
-        {
             "extractedText": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n\nLicenses for support code\n-------------------------\n\nParts of the TLS test suite are under the Go license. This code is not included\nin BoringSSL (i.e. libcrypto and libssl) when compiled, however, so\ndistributing code linked against BoringSSL does not trigger this license:\n\nCopyright (c) 2009 The Go Authors. All rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n   * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n   * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n   * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
             "licenseId": "LicenseRef-third-party-boringssl-src-license",
             "name": "MIT, BSD-3-Clause, OpenSSL, ISC, SSLeay"
-        },
-        {
-            "extractedText": "==============================================================================\nThe LLVM Project is under the Apache License v2.0 with LLVM Exceptions:\n==============================================================================\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n    1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n    2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n    3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n    4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n    5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n    6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n    7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n    8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n    9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n    END OF TERMS AND CONDITIONS\n\n    APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n    Copyright [yyyy] [name of copyright owner]\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n\n---- LLVM Exceptions to the Apache 2.0 License ----\n\nAs an exception, if, as a result of your compiling your source code, portions\nof this Software are embedded into an Object form of such source code, you\nmay redistribute such embedded portions in such Object form without complying\nwith the conditions of Sections 4(a), 4(b) and 4(d) of the License.\n\nIn addition, if you combine or link compiled forms of this Software with\nsoftware that is licensed under the GPLv2 (\"Combined Software\") and if a\ncourt of competent jurisdiction determines that the patent provision (Section\n3), the indemnity provision (Section 9) or other Section of the License\nconflicts with the conditions of the GPLv2, you may retroactively and\nprospectively choose to deem waived or otherwise exclude such Section(s) of\nthe License, but only in their entirety and only with respect to the Combined\nSoftware.\n\n==============================================================================\nSoftware from third parties included in the LLVM Project:\n==============================================================================\nThe LLVM Project contains third party software which is under different license\nterms. All such code will be identified clearly using at least one of two\nmechanisms:\n1) It will be in a separate directory tree with its own `LICENSE.txt` or\n   `LICENSE` file at the top containing the specific license and restrictions\n   which apply to that software, or\n2) It will contain specific license and restriction terms at the top of every\n   file.\n\n==============================================================================\nLegacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):\n==============================================================================\n\nThe compiler_rt library is dual licensed under both the University of Illinois\n\"BSD-Like\" license and the MIT license.  As a user of this code you may choose\nto use it under either license.  As a contributor, you agree to allow your code\nto be used under both.\n\nFull text of the relevant licenses is included below.\n\n==============================================================================\n\nUniversity of Illinois/NCSA\nOpen Source License\n\nCopyright (c) 2009-2019 by the contributors listed in CREDITS.TXT\n\nAll rights reserved.\n\nDeveloped by:\n\n    LLVM Team\n\n    University of Illinois at Urbana-Champaign\n\n    http://llvm.org\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal with\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\n    * Redistributions of source code must retain the above copyright notice,\n      this list of conditions and the following disclaimers.\n\n    * Redistributions in binary form must reproduce the above copyright notice,\n      this list of conditions and the following disclaimers in the\n      documentation and/or other materials provided with the distribution.\n\n    * Neither the names of the LLVM Team, University of Illinois at\n      Urbana-Champaign, nor the names of its contributors may be used to\n      endorse or promote products derived from this Software without specific\n      prior written permission.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\nFOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\nCONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n\n==============================================================================\n\nCopyright (c) 2009-2015 by the contributors listed in CREDITS.TXT\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-compiler-rt-src-license.txt",
-            "name": "NCSA, Apache-with-LLVM-Exception, MIT"
         },
         {
             "extractedText": "Copyright (C) 1997 Gregory Pietsch\n\n[These files] are hereby placed in the public domain without restrictions. Just\ngive the author credit, don't claim you wrote it or prevent anyone else from\nusing it.\n",
@@ -34,39 +19,9 @@
             "name": "Public domain"
         },
         {
-            "extractedText": "Copyright 2005-2011 Google LLC\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n   Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n   Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n   Neither the name of Google LLC nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-third-party-lss-license",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "Copyright 2013-2020 The Khronos Group Inc.\nSPDX-License-Identifier: Apache-2.0\n\nThis header is generated from the Khronos EGL XML API Registry.\nThe current version of the Registry, generator scripts\nused to make the header, and the header can be found at\n  http://www.khronos.org/registry/egl\n\nKhronos $Git commit SHA1: 6fb1daea15 $ on $Git commit date: 2022-05-25 09:41:13 -0600 $\n\n\nCopyright 2007-2020 The Khronos Group Inc.\nSPDX-License-Identifier: Apache-2.0\n\nPlatform-specific types and definitions for egl.h\n\nAdopters may modify khrplatform.h and this file to suit their platform.\nYou are encouraged to submit all modifications to the Khronos group so that\nthey can be included in future versions of this file.  Please submit changes\nby filing an issue or pull request on the public Khronos EGL Registry, at\nhttps://www.github.com/KhronosGroup/EGL-Registry/\n\n\nCopyright (c) 2013-2018 The Khronos Group Inc.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n\n\nCopyright (c) 2008-2018 The Khronos Group Inc.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and/or associated documentation files (the\n\"Materials\"), to deal in the Materials without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Materials, and to\npermit persons to whom the Materials are furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Materials.\n\nTHE MATERIALS ARE PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nMATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.\n\n",
-            "licenseId": "LicenseRef-third-party-dawn-third-party-egl-registry-license",
-            "name": "Apache-2.0, MIT"
-        },
-        {
             "extractedText": "==============================================================================\nLLVM Release License\n==============================================================================\nUniversity of Illinois/NCSA\nOpen Source License\n\nCopyright (c) 2003-2015 University of Illinois at Urbana-Champaign.\nAll rights reserved.\n\nDeveloped by:\n\n    LLVM Team\n\n    University of Illinois at Urbana-Champaign\n\n    http://llvm.org\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal with\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\n    * Redistributions of source code must retain the above copyright notice,\n      this list of conditions and the following disclaimers.\n\n    * Redistributions in binary form must reproduce the above copyright notice,\n      this list of conditions and the following disclaimers in the\n      documentation and/or other materials provided with the distribution.\n\n    * Neither the names of the LLVM Team, University of Illinois at\n      Urbana-Champaign, nor the names of its contributors may be used to\n      endorse or promote products derived from this Software without specific\n      prior written permission.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\nFOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\nCONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n\n==============================================================================\nCopyrights and Licenses for Third Party Software Distributed with LLVM:\n==============================================================================\nThe LLVM software contains code written by third parties.  Such software will\nhave its own individual LICENSE.TXT file in the directory in which it appears.\nThis file will describe the copyrights, license, and restrictions which apply\nto that code.\n\nThe disclaimer of warranty in the University of Illinois Open Source License\napplies to all code in the LLVM Distribution, and nothing in any of the\nother licenses gives permission to use the names of the LLVM Team or the\nUniversity of Illinois to endorse or promote products derived from this\nSoftware.\n\n------------------\n\nFiles: lib/Miniz/* include/miniz/*\n\nCopyright 2013-2014 RAD Game Tools and Valve Software\nCopyright 2010-2014 Rich Geldreich and Tenacious Software LLC\n\nAll Rights Reserved.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n\n------------------\n\nFiles: lib/Miniz/miniz.c\n\nThis is free and unencumbered software released into the public domain.\n\nAnyone is free to copy, modify, publish, use, compile, sell, or\ndistribute this software, either in source code form or as a compiled\nbinary, for any purpose, commercial or non-commercial, and by any\nmeans.\n\nIn jurisdictions that recognize copyright laws, the author or authors\nof this software dedicate any and all copyright interest in the\nsoftware to the public domain. We make this dedication for the benefit\nof the public at large and to the detriment of our heirs and\nsuccessors. We intend this dedication to be an overt act of\nrelinquishment in perpetuity of all present and future rights to this\nsoftware under copyright law.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR\nOTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\nARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\nOTHER DEALINGS IN THE SOFTWARE.\n\nFor more information, please refer to <http://unlicense.org/>\n\n------------------\n\nFiles: lib/Support/* docs/SystemLibrary.rst\n\nWritten by Henry Spencer.  Not derived from licensed software.\n\nPermission is granted to anyone to use this software for any\npurpose on any computer system, and to redistribute it freely,\nsubject to the following restrictions:\n\n1. The author is not responsible for the consequences of use of\n        this software, no matter how awful, even if they arise\n        from defects in it.\n\n2. The origin of this software must not be misrepresented, either\n        by explicit claim or by omission.\n\n3. Altered versions must be plainly marked as such, and must not\n        be misrepresented as being the original software.\n\n------------------\n\nFiles: include/llvm/Support/ConvertUTF.h\n\nCopyright 2001-2004 Unicode, Inc.\n\nDisclaimer\n\nThis source code is provided as is by Unicode, Inc. No claims are\nmade as to fitness for any particular purpose. No warranties of any\nkind are expressed or implied. The recipient agrees to determine\napplicability of information provided. If this file has been\npurchased on magnetic or optical media from Unicode, Inc., the\nsole remedy for any claim will be exchange of defective media\nwithin 90 days of receipt.\n\nLimitations on Rights to Redistribute This Code\n\nUnicode, Inc. hereby grants the right to freely use the information\nsupplied in this file in the creation of products supporting the\nUnicode Standard, and to make copies of this file in any form\nfor internal or external distribution as long as this notice\nremains attached.\n\n------------------\n\nFiles: include/llvm/Support/MD5.h\n\nThis software was written by Alexander Peslyak in 2001.  No copyright is\nclaimed, and the software is hereby placed in the public domain.\nIn case this attempt to disclaim copyright and place the software in the\npublic domain is deemed null and void, then the software is\nCopyright (c) 2001 Alexander Peslyak and it is hereby released to the\ngeneral public under the following terms:\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted.\n\nThere's ABSOLUTELY NO WARRANTY, express or implied.\n\n------------------\n\nFiles: lib/Support/regstrlcpy.c\n\nCopyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>\n\nPermission to use, copy, modify, and distribute this software for any\npurpose with or without fee is hereby granted, provided that the above\ncopyright notice and this permission notice appear in all copies.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES\nWITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF\nMERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR\nANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES\nWHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN\nACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF\nOR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.\n\n\n\n\n------------------\n------------------\n\nTHE FOLLOWING LICENSES ARE FOR BUILD AND TEST DEPENDENCIES ONLY.\n\n------------------\n------------------\n\nFiles: utils/unittest/googletest/*\n\nCopyright 2008, Google Inc.\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n------------------\n\nFiles: utils/unittest/googlemock/*\n\nCopyright 2008, Google Inc.\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n------------------\n\nFiles: test/YamlParser/*\n\nCopyright (c) 2006 Kirill Simonov\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal in\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n\n------------------\n\nFiles: autoconf/config.guess\n\n                    GNU GENERAL PUBLIC LICENSE\n                       Version 2, June 1991\n\n Copyright (C) 1989, 1991 Free Software Foundation, Inc.,\n 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n                            Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicense is intended to guarantee your freedom to share and change free\nsoftware--to make sure the software is free for all its users.  This\nGeneral Public License applies to most of the Free Software\nFoundation's software and to any other program whose authors commit to\nusing it.  (Some other Free Software Foundation software is covered by\nthe GNU Lesser General Public License instead.)  You can apply it to\nyour programs, too.\n\n  When we speak of free software, we are referring to freedom, not\nprice.  Our General Public Licenses are designed to make sure that you\nhave the freedom to distribute copies of free software (and charge for\nthis service if you wish), that you receive source code or can get it\nif you want it, that you can change the software or use pieces of it\nin new free programs; and that you know you can do these things.\n\n  To protect your rights, we need to make restrictions that forbid\nanyone to deny you these rights or to ask you to surrender the rights.\nThese restrictions translate to certain responsibilities for you if you\ndistribute copies of the software, or if you modify it.\n\n  For example, if you distribute copies of such a program, whether\ngratis or for a fee, you must give the recipients all the rights that\nyou have.  You must make sure that they, too, receive or can get the\nsource code.  And you must show them these terms so they know their\nrights.\n\n  We protect your rights with two steps: (1) copyright the software, and\n(2) offer you this license which gives you legal permission to copy,\ndistribute and/or modify the software.\n\n  Also, for each author's protection and ours, we want to make certain\nthat everyone understands that there is no warranty for this free\nsoftware.  If the software is modified by someone else and passed on, we\nwant its recipients to know that what they have is not the original, so\nthat any problems introduced by others will not reflect on the original\nauthors' reputations.\n\n  Finally, any free program is threatened constantly by software\npatents.  We wish to avoid the danger that redistributors of a free\nprogram will individually obtain patent licenses, in effect making the\nprogram proprietary.  To prevent this, we have made it clear that any\npatent must be licensed for everyone's free use or not licensed at all.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.\n\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License applies to any program or other work which contains\na notice placed by the copyright holder saying it may be distributed\nunder the terms of this General Public License.  The \"Program\", below,\nrefers to any such program or work, and a \"work based on the Program\"\nmeans either the Program or any derivative work under copyright law:\nthat is to say, a work containing the Program or a portion of it,\neither verbatim or with modifications and/or translated into another\nlanguage.  (Hereinafter, translation is included without limitation in\nthe term \"modification\".)  Each licensee is addressed as \"you\".\n\nActivities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning the Program is not restricted, and the output from the Program\nis covered only if its contents constitute a work based on the\nProgram (independent of having been made by running the Program).\nWhether that is true depends on what the Program does.\n\n  1. You may copy and distribute verbatim copies of the Program's\nsource code as you receive it, in any medium, provided that you\nconspicuously and appropriately publish on each copy an appropriate\ncopyright notice and disclaimer of warranty; keep intact all the\nnotices that refer to this License and to the absence of any warranty;\nand give any other recipients of the Program a copy of this License\nalong with the Program.\n\nYou may charge a fee for the physical act of transferring a copy, and\nyou may at your option offer warranty protection in exchange for a fee.\n\n  2. You may modify your copy or copies of the Program or any portion\nof it, thus forming a work based on the Program, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) You must cause the modified files to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    b) You must cause any work that you distribute or publish, that in\n    whole or in part contains or is derived from the Program or any\n    part thereof, to be licensed as a whole at no charge to all third\n    parties under the terms of this License.\n\n    c) If the modified program normally reads commands interactively\n    when run, you must cause it, when started running for such\n    interactive use in the most ordinary way, to print or display an\n    announcement including an appropriate copyright notice and a\n    notice that there is no warranty (or else, saying that you provide\n    a warranty) and that users may redistribute the program under\n    these conditions, and telling the user how to view a copy of this\n    License.  (Exception: if the Program itself is interactive but\n    does not normally print such an announcement, your work based on\n    the Program is not required to print an announcement.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Program,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Program, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote it.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Program.\n\nIn addition, mere aggregation of another work not based on the Program\nwith the Program (or with a work based on the Program) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may copy and distribute the Program (or a work based on it,\nunder Section 2) in object code or executable form under the terms of\nSections 1 and 2 above provided that you also do one of the following:\n\n    a) Accompany it with the complete corresponding machine-readable\n    source code, which must be distributed under the terms of Sections\n    1 and 2 above on a medium customarily used for software interchange; or,\n\n    b) Accompany it with a written offer, valid for at least three\n    years, to give any third party, for a charge no more than your\n    cost of physically performing source distribution, a complete\n    machine-readable copy of the corresponding source code, to be\n    distributed under the terms of Sections 1 and 2 above on a medium\n    customarily used for software interchange; or,\n\n    c) Accompany it with the information you received as to the offer\n    to distribute corresponding source code.  (This alternative is\n    allowed only for noncommercial distribution and only if you\n    received the program in object code or executable form with such\n    an offer, in accord with Subsection b above.)\n\nThe source code for a work means the preferred form of the work for\nmaking modifications to it.  For an executable work, complete source\ncode means all the source code for all modules it contains, plus any\nassociated interface definition files, plus the scripts used to\ncontrol compilation and installation of the executable.  However, as a\nspecial exception, the source code distributed need not include\nanything that is normally distributed (in either source or binary\nform) with the major components (compiler, kernel, and so on) of the\noperating system on which the executable runs, unless that component\nitself accompanies the executable.\n\nIf distribution of executable or object code is made by offering\naccess to copy from a designated place, then offering equivalent\naccess to copy the source code from the same place counts as\ndistribution of the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  4. You may not copy, modify, sublicense, or distribute the Program\nexcept as expressly provided under this License.  Any attempt\notherwise to copy, modify, sublicense or distribute the Program is\nvoid, and will automatically terminate your rights under this License.\nHowever, parties who have received copies, or rights, from you under\nthis License will not have their licenses terminated so long as such\nparties remain in full compliance.\n\n  5. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Program or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Program (or any work based on the\nProgram), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Program or works based on it.\n\n  6. Each time you redistribute the Program (or any work based on the\nProgram), the recipient automatically receives a license from the\noriginal licensor to copy, distribute or modify the Program subject to\nthese terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties to\nthis License.\n\n  7. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Program at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Program by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Program.\n\nIf any portion of this section is held invalid or unenforceable under\nany particular circumstance, the balance of the section is intended to\napply and the section as a whole is intended to apply in other\ncircumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system, which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  8. If the distribution and/or use of the Program is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Program under this License\nmay add an explicit geographical distribution limitation excluding\nthose countries, so that distribution is permitted only in or among\ncountries not thus excluded.  In such case, this License incorporates\nthe limitation as if written in the body of this License.\n\n  9. The Free Software Foundation may publish revised and/or new versions\nof the General Public License from time to time.  Such new versions will\nbe similar in spirit to the present version, but may differ in detail to\naddress new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Program\nspecifies a version number of this License which applies to it and \"any\nlater version\", you have the option of following the terms and conditions\neither of that version or of any later version published by the Free\nSoftware Foundation.  If the Program does not specify a version number of\nthis License, you may choose any version ever published by the Free Software\nFoundation.\n\n  10. If you wish to incorporate parts of the Program into other free\nprograms whose distribution conditions are different, write to the author\nto ask for permission.  For software which is copyrighted by the Free\nSoftware Foundation, write to the Free Software Foundation; we sometimes\nmake exceptions for this.  Our decision will be guided by the two goals\nof preserving the free status of all derivatives of our free software and\nof promoting the sharing and reuse of software generally.\n\n                            NO WARRANTY\n\n  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY\nFOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN\nOTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES\nPROVIDE THE PROGRAM \"AS IS\" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED\nOR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\nMERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS\nTO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE\nPROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,\nREPAIR OR CORRECTION.\n\n  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING\nWILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR\nREDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,\nINCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING\nOUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED\nTO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY\nYOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER\nPROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE\nPOSSIBILITY OF SUCH DAMAGES.\n\nAutoconf Exception\n\nAs a special exception, the Free Software Foundation gives unlimited\npermission to copy, distribute and modify the configure scripts that are the\noutput of Autoconf. You need not follow the terms of the GNU General Public\nLicense when using or distributing such scripts, even though portions of the\ntext of Autoconf appear in them. The GNU General Public License (GPL) does\ngovern all other use of the material that constitutes the Autoconf program.\n\nCertain portions of the Autoconf source text are designed to be copied (in\ncertain cases, depending on the input) into the output of Autoconf. We call\nthese the \"data\" portions. The rest of the Autoconf source text consists of\ncomments plus executable code that decides which of the data portions to\noutput in any given case. We call these comments and executable code the \"non-\ndata\" portions. Autoconf never copies any of the non-data portions into its\noutput.\n\nThis special exception to the GPL applies to versions of Autoconf released by\nthe Free Software Foundation. When you make and distribute a modified version\nof Autoconf, you may extend this special exception to the GPL to apply to your\nmodified version as well, *unless* your modified version has the potential to\ncopy into its output some of the text that was the non-data portion of the\nversion that you started with. (In other words, unless your change moves or\ncopies text from the non-data portions to the data portions.) If your\nmodification has such potential, you must delete any notice of this special\nexception to the GPL from your modified version.\n\n                     END OF TERMS AND CONDITIONS\n",
             "licenseId": "LicenseRef-third-party-dawn-third-party-dxc-license.txt",
             "name": "LLVM Release License"
-        },
-        {
-            "extractedText": "## Marked\n\nCopyright (c) 2011-2018, Christopher Jeffrey (https://github.com/chjj/)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n\n## Markdown\n\nCopyright \u00a9 2004, John Gruber\nhttp://daringfireball.net/\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\n* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n* Neither the name \u201cMarkdown\u201d nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\n\nThis software is provided by the copyright holders and contributors \u201cas is\u201d and any express or implied warranties, including, but not limited to,\nthe implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct,\nindirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits;\nor business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way\nout of the use of this software, even if advised of the possibility of such damage.\n",
-            "licenseId": "LicenseRef-third-party-devtools-frontend-src-front-end-third-party-marked-license",
-            "name": "BSD-3-Clause, MIT"
-        },
-        {
-            "extractedText": "Copyright 2014 The Chromium Authors\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n   * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n   * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n   * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n\n\nParts of the following directories are available under Apache v2.0\n\nsrc/de\nCopyright (c) 2009-2011 Christian Kohlsch\u00fctter\n\nthird_party/gwt_exporter\nCopyright 2007 Timepedia.org\n\nthird_party/gwt-2.5.1\nCopyright 2008 Google\n\njava/org/chromium/distiller/dev\nCopyright 2008 Google\n\nApache License\n\nVersion 2.0, January 2004\n\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n\"License\" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\n\n\"Licensor\" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\n\n\"Legal Entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\n\n\"You\" (or \"Your\") shall mean an individual or Legal Entity exercising permissions granted by this License.\n\n\"Source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\n\n\"Object\" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\n\n\"Work\" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\n\n\"Derivative Works\" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\n\n\"Contribution\" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as \"Not a Contribution.\"\n\n\"Contributor\" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\n\nYou must give any other recipients of the Work or Derivative Works a copy of this License; and\nYou must cause any modified files to carry prominent notices stating that You changed the files; and\nYou must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\nIf the Work includes a \"NOTICE\" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. \n\nYou may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\n5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n",
-            "licenseId": "LicenseRef-third-party-dom-distiller-js-license",
-            "name": "BSD-3-Clause, Apache-2.0"
-        },
-        {
-            "extractedText": "                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n    1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n    2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n    3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n    4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n    5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n    6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n    7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n    8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n    9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n    END OF TERMS AND CONDITIONS\n\n    APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n    Copyright [yyyy] [name of copyright owner]\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n\n--- LLVM Exceptions to the Apache 2.0 License ----\n\nAs an exception, if, as a result of your compiling your source code, portions\nof this Software are embedded into an Object form of such source code, you\nmay redistribute such embedded portions in such Object form without complying\nwith the conditions of Sections 4(a), 4(b) and 4(d) of the License.\n\nIn addition, if you combine or link compiled forms of this Software with\nsoftware that is licensed under the GPLv2 (\"Combined Software\") and if a\ncourt of competent jurisdiction determines that the patent provision (Section\n3), the indemnity provision (Section 9) or other Section of the License\nconflicts with the conditions of the GPLv2, you may retroactively and\nprospectively choose to deem waived or otherwise exclude such Section(s) of\nthe License, but only in their entirety and only with respect to the Combined\nSoftware.\n",
-            "licenseId": "LicenseRef-third-party-dragonbox-src-license-apache2-llvm",
-            "name": "Apache-with-LLVM-Exception, BSL-1.0"
-        },
-        {
-            "extractedText": "Boost Software License - Version 1.0 - August 17th, 2003\n\nPermission is hereby granted, free of charge, to any person or organization\nobtaining a copy of the software and accompanying documentation covered by\nthis license (the \"Software\") to use, reproduce, display, distribute,\nexecute, and transmit the Software, and to prepare derivative works of the\nSoftware, and to permit third-parties to whom the Software is furnished to\ndo so, all subject to the following:\n\nThe copyright notices in the Software and this entire statement, including\nthe above license grant, this restriction and the following disclaimer,\nmust be included in all copies of the Software, in whole or in part, and\nall derivative works of the Software, unless such copies or derivative\nworks are solely in the form of machine-executable object code generated by\na source language processor.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT\nSHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE\nFOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,\nARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-dragonbox-src-license-boost",
-            "name": "Apache-with-LLVM-Exception, BSL-1.0"
         },
         {
             "extractedText": "Copyright(C) 1997,2001 Takuya OOURA (email: ooura@kurims.kyoto-u.ac.jp).\nYou may use, copy, modify this code for any purpose and \nwithout fee. You may distribute this ORIGINAL package.\n",
@@ -77,16 +32,6 @@
             "extractedText": "fontconfig/COPYING\n\nCopyright \u00a9 2000,2001,2002,2003,2004,2006,2007 Keith Packard\nCopyright \u00a9 2005 Patrick Lam\nCopyright \u00a9 2007 Dwayne Bailey and Translate.org.za\nCopyright \u00a9 2009 Roozbeh Pournader\nCopyright \u00a9 2008,2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020 Red Hat, Inc.\nCopyright \u00a9 2008 Danilo \u0160egan\nCopyright \u00a9 2012 Google, Inc.\n\n\nPermission to use, copy, modify, distribute, and sell this software and its\ndocumentation for any purpose is hereby granted without fee, provided that\nthe above copyright notice appear in all copies and that both that\ncopyright notice and this permission notice appear in supporting\ndocumentation, and that the name of the author(s) not be used in\nadvertising or publicity pertaining to distribution of the software without\nspecific, written prior permission.  The authors make no\nrepresentations about the suitability of this software for any purpose.  It\nis provided \"as is\" without express or implied warranty.\n\nTHE AUTHOR(S) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,\nINCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO\nEVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY SPECIAL, INDIRECT OR\nCONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,\nDATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER\nTORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR\nPERFORMANCE OF THIS SOFTWARE.\n\n\n--------------------------------------------------------------------------------\nfontconfig/fc-case/CaseFolding.txt\n\n\u00a9 2019 Unicode\u00ae, Inc.\nUnicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.\nFor terms of use, see http://www.unicode.org/terms_of_use.html\n\n\n--------------------------------------------------------------------------------\nfontconfig/src/fcatomic.h\n\n/*\n * Mutex operations.  Originally copied from HarfBuzz.\n *\n * Copyright \u00a9 2007  Chris Wilson\n * Copyright \u00a9 2009,2010  Red Hat, Inc.\n * Copyright \u00a9 2011,2012,2013  Google, Inc.\n *\n * Permission is hereby granted, without written agreement and without\n * license or royalty fees, to use, copy, modify, and distribute this\n * software and its documentation for any purpose, provided that the\n * above copyright notice and the following two paragraphs appear in\n * all copies of this software.\n *\n * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR\n * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES\n * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN\n * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\n * DAMAGE.\n *\n * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,\n * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND\n * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS\n * ON AN \"AS IS\" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO\n * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.\n *\n * Contributor(s):\n *\tChris Wilson <chris@chris-wilson.co.uk>\n * Red Hat Author(s): Behdad Esfahbod\n * Google Author(s): Behdad Esfahbod\n */\n\n\n--------------------------------------------------------------------------------\nfontconfig/src/fcfoundry.h\n\n/*\n  Copyright \u00a9 2002-2003 by Juliusz Chroboczek\n\n  Permission is hereby granted, free of charge, to any person obtaining a copy\n  of this software and associated documentation files (the \"Software\"), to deal\n  in the Software without restriction, including without limitation the rights\n  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n  copies of the Software, and to permit persons to whom the Software is\n  furnished to do so, subject to the following conditions:\n\n  The above copyright notice and this permission notice shall be included in\n  all copies or substantial portions of the Software.\n\n  THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\n  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n  THE SOFTWARE.\n*/\n\n\n--------------------------------------------------------------------------------\nfontconfig/src/fcmd5.h\n\n/*\n * This code implements the MD5 message-digest algorithm.\n * The algorithm is due to Ron Rivest.  This code was\n * written by Colin Plumb in 1993, no copyright is claimed.\n * This code is in the public domain; do with it what you wish.\n *\n * Equivalent code is available from RSA Data Security, Inc.\n * This code has been tested against that, and is equivalent,\n * except that you don't need to include two pages of legalese\n * with every copy.\n *\n * To compute the message digest of a chunk of bytes, declare an\n * MD5Context structure, pass it to MD5Init, call MD5Update as\n * needed on buffers full of bytes, and then call MD5Final, which\n * will fill a supplied 16-byte array with the digest.\n */\n\n\n--------------------------------------------------------------------------------\nfontconfig/src/fcmutex.h\n\n/*\n * Atomic int and pointer operations.  Originally copied from HarfBuzz.\n *\n * Copyright \u00a9 2007  Chris Wilson\n * Copyright \u00a9 2009,2010  Red Hat, Inc.\n * Copyright \u00a9 2011,2012,2013  Google, Inc.\n *\n * Permission is hereby granted, without written agreement and without\n * license or royalty fees, to use, copy, modify, and distribute this\n * software and its documentation for any purpose, provided that the\n * above copyright notice and the following two paragraphs appear in\n * all copies of this software.\n *\n * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR\n * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES\n * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN\n * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\n * DAMAGE.\n *\n * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,\n * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND\n * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS\n * ON AN \"AS IS\" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO\n * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.\n *\n * Contributor(s):\n *\tChris Wilson <chris@chris-wilson.co.uk>\n * Red Hat Author(s): Behdad Esfahbod\n * Google Author(s): Behdad Esfahbod\n */\n\n\n--------------------------------------------------------------------------------\nfontconfig/src/ftglue.[ch]\n\n/* ftglue.c: Glue code for compiling the OpenType code from\n *           FreeType 1 using only the public API of FreeType 2\n *\n * By David Turner, The FreeType Project (www.freetype.org)\n *\n * This code is explicitely put in the public domain\n *\n * ==========================================================================\n *\n * the OpenType parser codes was originally written as an extension to\n * FreeType 1.x. As such, its source code was embedded within the library,\n * and used many internal FreeType functions to deal with memory and\n * stream i/o.\n *\n * When it was 'salvaged' for Pango and Qt, the code was \"ported\" to FreeType 2,\n * which basically means that some macro tricks were performed in order to\n * directly access FT2 _internal_ functions.\n *\n * these functions were never part of FT2 public API, and _did_ change between\n * various releases. This created chaos for many users: when they upgraded the\n * FreeType library on their system, they couldn't run Gnome anymore since\n * Pango refused to link.\n *\n * Very fortunately, it's possible to completely avoid this problem because\n * the FT_StreamRec and FT_MemoryRec structure types, which describe how\n * memory and stream implementations interface with the rest of the font\n * library, have always been part of the public API, and never changed.\n *\n * What we do thus is re-implement, within the OpenType parser, the few\n * functions that depend on them. This only adds one or two kilobytes of\n * code, and ensures that the parser can work with _any_ version\n * of FreeType installed on your system. How sweet... !\n *\n * Note that we assume that Pango doesn't use any other internal functions\n * from FreeType. It used to in old versions, but this should no longer\n * be the case. (crossing my fingers).\n *\n *  - David Turner\n *  - The FreeType Project  (www.freetype.org)\n *\n * PS: This \"glue\" code is explicitely put in the public domain\n */\n",
             "licenseId": "LicenseRef-third-party-fontconfig-src-copying",
             "name": "public-domain-md5, MIT-Modern-Variant, HPND-sell-variant, MIT"
-        },
-        {
-            "extractedText": "/*************************************************************************\n *\n *  IAccessible2 IDL Specification \n * \n *  Copyright (c) 2007, 2010 Linux Foundation \n *  Copyright (c) 2006 IBM Corporation \n *  Copyright (c) 2000, 2006 Sun Microsystems, Inc. \n *  All rights reserved. \n *   \n *   \n *  Redistribution and use in source and binary forms, with or without \n *  modification, are permitted provided that the following conditions \n *  are met: \n *   \n *   1. Redistributions of source code must retain the above copyright \n *      notice, this list of conditions and the following disclaimer. \n *   \n *   2. Redistributions in binary form must reproduce the above \n *      copyright notice, this list of conditions and the following \n *      disclaimer in the documentation and/or other materials \n *      provided with the distribution. \n *\n *   3. Neither the name of the Linux Foundation nor the names of its \n *      contributors may be used to endorse or promote products \n *      derived from this software without specific prior written \n *      permission. \n *   \n *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND \n *  CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, \n *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF \n *  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE \n *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR \n *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, \n *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT \n *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; \n *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) \n *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN \n *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR \n *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \n *  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. \n *   \n *  This BSD License conforms to the Open Source Initiative \"Simplified \n *  BSD License\" as published at: \n *  http://www.opensource.org/licenses/bsd-license.php \n *   \n *  IAccessible2 is a trademark of the Linux Foundation. The IAccessible2 \n *  mark may be used in accordance with the Linux Foundation Trademark \n *  Policy to indicate compliance with the IAccessible2 specification. \n * \n ************************************************************************/ \n",
-            "licenseId": "LicenseRef-third-party-iaccessible2-license",
-            "name": "BSD-3-Clause, BSD-2-Clause"
-        },
-        {
-            "extractedText": "// Copyright 2022 The Chromium Authors\n//\n// Redistribution and use in source and binary forms, with or without\n// modification, are permitted provided that the following conditions are\n// met:\n//\n//    * Redistributions of source code must retain the above copyright\n// notice, this list of conditions and the following disclaimer.\n//    * Redistributions in binary form must reproduce the above\n// copyright notice, this list of conditions and the following disclaimer\n// in the documentation and/or other materials provided with the\n// distribution.\n//    * Neither the name of Google LLC nor the names of its\n// contributors may be used to endorse or promote products derived from\n// this software without specific prior written permission.\n//\n// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n// \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-third-party-ipcz-license",
-            "name": "BSD"
         },
         {
             "extractedText": "The JsonCpp library's source code, including accompanying documentation, \ntests and demonstration applications, are licensed under the following\nconditions...\n\nThe author (Baptiste Lepilleur) explicitly disclaims copyright in all \njurisdictions which recognize such a disclaimer. In such jurisdictions, \nthis software is released into the Public Domain.\n\nIn jurisdictions which do not recognize Public Domain property (e.g. Germany as of\n2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is\nreleased under the terms of the MIT License (see below).\n\nIn jurisdictions which recognize Public Domain property, the user of this \nsoftware may choose to accept it either as 1) Public Domain, 2) under the \nconditions of the MIT License (see below), or 3) under the terms of dual \nPublic Domain/MIT License conditions described here, as they choose.\n\nThe MIT License is about as close to Public Domain as a license can get, and is\ndescribed in clear, concise terms at:\n\n   http://en.wikipedia.org/wiki/MIT_License\n   \nThe full text of the MIT License follows:\n\n========================================================================\nCopyright (c) 2007-2010 Baptiste Lepilleur\n\nPermission is hereby granted, free of charge, to any person\nobtaining a copy of this software and associated documentation\nfiles (the \"Software\"), to deal in the Software without\nrestriction, including without limitation the rights to use, copy,\nmodify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS\nBE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN\nACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN\nCONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n========================================================================\n(END LICENSE TEXT)\n\nThe MIT license is compatible with both the GPL and commercial\nsoftware, affording one all of the rights of Public Domain with the\nminor nuisance of being required to keep the above copyright notice\nand license text in the source code. Note also that by accepting the\nPublic Domain \"license\" you can re-license your copy using whatever\nlicense you like.\n",
@@ -102,26 +47,6 @@
             "extractedText": "Alliance for Open Media Patent License 1.0\n\n1. License Terms.\n\n1.1. Patent License. Subject to the terms and conditions of this License, each\n     Licensor, on behalf of itself and successors in interest and assigns,\n     grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive,\n     no-charge, royalty-free, irrevocable (except as expressly stated in this\n     License) patent license to its Necessary Claims to make, use, sell, offer\n     for sale, import or distribute any Implementation.\n\n1.2. Conditions.\n\n1.2.1. Availability. As a condition to the grant of rights to Licensee to make,\n       sell, offer for sale, import or distribute an Implementation under\n       Section 1.1, Licensee must make its Necessary Claims available under\n       this License, and must reproduce this License with any Implementation\n       as follows:\n\n       a. For distribution in source code, by including this License in the\n          root directory of the source code with its Implementation.\n\n       b. For distribution in any other form (including binary, object form,\n          and/or hardware description code (e.g., HDL, RTL, Gate Level Netlist,\n          GDSII, etc.)), by including this License in the documentation, legal\n          notices, and/or other written materials provided with the\n          Implementation.\n\n1.2.2. Additional Conditions. This license is directly from Licensor to\n       Licensee.  Licensee acknowledges as a condition of benefiting from it\n       that no rights from Licensor are received from suppliers, distributors,\n       or otherwise in connection with this License.\n\n1.3. Defensive Termination. If any Licensee, its Affiliates, or its agents\n     initiates patent litigation or files, maintains, or voluntarily\n     participates in a lawsuit against another entity or any person asserting\n     that any Implementation infringes Necessary Claims, any patent licenses\n     granted under this License directly to the Licensee are immediately\n     terminated as of the date of the initiation of action unless 1) that suit\n     was in response to a corresponding suit regarding an Implementation first\n     brought against an initiating entity, or 2) that suit was brought to\n     enforce the terms of this License (including intervention in a third-party\n     action by a Licensee).\n\n1.4. Disclaimers. The Reference Implementation and Specification are provided\n     \"AS IS\" and without warranty. The entire risk as to implementing or\n     otherwise using the Reference Implementation or Specification is assumed\n     by the implementer and user. Licensor expressly disclaims any warranties\n     (express, implied, or otherwise), including implied warranties of\n     merchantability, non-infringement, fitness for a particular purpose, or\n     title, related to the material. IN NO EVENT WILL LICENSOR BE LIABLE TO\n     ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL,\n     INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF\n     ACTION OF ANY KIND WITH RESPECT TO THIS LICENSE, WHETHER BASED ON BREACH\n     OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR\n     NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n2. Definitions.\n\n2.1. Affiliate.  \"Affiliate\" means an entity that directly or indirectly\n     Controls, is Controlled by, or is under common Control of that party.\n\n2.2. Control. \"Control\" means direct or indirect control of more than 50% of\n     the voting power to elect directors of that corporation, or for any other\n     entity, the power to direct management of such entity.\n\n2.3. Decoder.  \"Decoder\" means any decoder that conforms fully with all\n     non-optional portions of the Specification.\n\n2.4. Encoder.  \"Encoder\" means any encoder that produces a bitstream that can\n     be decoded by a Decoder only to the extent it produces such a bitstream.\n\n2.5. Final Deliverable.  \"Final Deliverable\" means the final version of a\n     deliverable approved by the Alliance for Open Media as a Final\n     Deliverable.\n\n2.6. Implementation.  \"Implementation\" means any implementation, including the\n     Reference Implementation, that is an Encoder and/or a Decoder. An\n     Implementation also includes components of an Implementation only to the\n     extent they are used as part of an Implementation.\n\n2.7. License. \"License\" means this license.\n\n2.8. Licensee. \"Licensee\" means any person or entity who exercises patent\n     rights granted under this License.\n\n2.9. Licensor.  \"Licensor\" means (i) any Licensee that makes, sells, offers\n     for sale, imports or distributes any Implementation, or (ii) a person\n     or entity that has a licensing obligation to the Implementation as a\n     result of its membership and/or participation in the Alliance for Open\n     Media working group that developed the Specification.\n\n2.10. Necessary Claims.  \"Necessary Claims\" means all claims of patents or\n      patent applications, (a) that currently or at any time in the future,\n      are owned or controlled by the Licensor, and (b) (i) would be an\n      Essential Claim as defined by the W3C Policy as of February 5, 2004\n      (https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential)\n      as if the Specification was a W3C Recommendation; or (ii) are infringed\n      by the Reference Implementation.\n\n2.11. Reference Implementation. \"Reference Implementation\" means an Encoder\n      and/or Decoder released by the Alliance for Open Media as a Final\n      Deliverable.\n\n2.12. Specification. \"Specification\" means the specification designated by\n      the Alliance for Open Media as a Final Deliverable for which this\n      License was issued.\n\n",
             "licenseId": "LicenseRef-third-party-libaom-source-libaom-patents",
             "name": "BSD-2-Clause, Patent"
-        },
-        {
-            "extractedText": "Copyright (c) 2006, 2008 Edward Rosten\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n\n\t*Redistributions of source code must retain the above copyright\n\t notice, this list of conditions and the following disclaimer.\n\n\t*Redistributions in binary form must reproduce the above copyright\n\t notice, this list of conditions and the following disclaimer in the\n\t documentation and/or other materials provided with the distribution.\n\n\t*Neither the name of the University of Cambridge nor the names of\n\t its contributors may be used to endorse or promote products derived\n\t from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR\nCONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\nPROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR\nPROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF\nLIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\nNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-third-party-libaom-source-libaom-third-party-fastfeat-license",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "==============================================================================\nThe LLVM Project is under the Apache License v2.0 with LLVM Exceptions:\n==============================================================================\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n    1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n    2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n    3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n    4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n    5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n    6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n    7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n    8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n    9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n    END OF TERMS AND CONDITIONS\n\n    APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n    Copyright [yyyy] [name of copyright owner]\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n\n---- LLVM Exceptions to the Apache 2.0 License ----\n\nAs an exception, if, as a result of your compiling your source code, portions\nof this Software are embedded into an Object form of such source code, you\nmay redistribute such embedded portions in such Object form without complying\nwith the conditions of Sections 4(a), 4(b) and 4(d) of the License.\n\nIn addition, if you combine or link compiled forms of this Software with\nsoftware that is licensed under the GPLv2 (\"Combined Software\") and if a\ncourt of competent jurisdiction determines that the patent provision (Section\n3), the indemnity provision (Section 9) or other Section of the License\nconflicts with the conditions of the GPLv2, you may retroactively and\nprospectively choose to deem waived or otherwise exclude such Section(s) of\nthe License, but only in their entirety and only with respect to the Combined\nSoftware.\n\n==============================================================================\nSoftware from third parties included in the LLVM Project:\n==============================================================================\nThe LLVM Project contains third party software which is under different license\nterms. All such code will be identified clearly using at least one of two\nmechanisms:\n1) It will be in a separate directory tree with its own `LICENSE.txt` or\n   `LICENSE` file at the top containing the specific license and restrictions\n   which apply to that software, or\n2) It will contain specific license and restriction terms at the top of every\n   file.\n\n==============================================================================\nLegacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):\n==============================================================================\n\nThe libc++ library is dual licensed under both the University of Illinois\n\"BSD-Like\" license and the MIT license.  As a user of this code you may choose\nto use it under either license.  As a contributor, you agree to allow your code\nto be used under both.\n\nFull text of the relevant licenses is included below.\n\n==============================================================================\n\nUniversity of Illinois/NCSA\nOpen Source License\n\nCopyright (c) 2009-2019 by the contributors listed in CREDITS.TXT\n\nAll rights reserved.\n\nDeveloped by:\n\n    LLVM Team\n\n    University of Illinois at Urbana-Champaign\n\n    http://llvm.org\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal with\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\n    * Redistributions of source code must retain the above copyright notice,\n      this list of conditions and the following disclaimers.\n\n    * Redistributions in binary form must reproduce the above copyright notice,\n      this list of conditions and the following disclaimers in the\n      documentation and/or other materials provided with the distribution.\n\n    * Neither the names of the LLVM Team, University of Illinois at\n      Urbana-Champaign, nor the names of its contributors may be used to\n      endorse or promote products derived from this Software without specific\n      prior written permission.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\nFOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\nCONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n\n==============================================================================\n\nCopyright (c) 2009-2014 by the contributors listed in CREDITS.TXT\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-libc---src-license.txt",
-            "name": "NCSA, Apache-with-LLVM-Exception, MIT"
-        },
-        {
-            "extractedText": "==============================================================================\nThe LLVM Project is under the Apache License v2.0 with LLVM Exceptions:\n==============================================================================\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n    1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n    2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n    3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n    4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n    5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n    6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n    7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n    8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n    9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n    END OF TERMS AND CONDITIONS\n\n    APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n    Copyright [yyyy] [name of copyright owner]\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n\n---- LLVM Exceptions to the Apache 2.0 License ----\n\nAs an exception, if, as a result of your compiling your source code, portions\nof this Software are embedded into an Object form of such source code, you\nmay redistribute such embedded portions in such Object form without complying\nwith the conditions of Sections 4(a), 4(b) and 4(d) of the License.\n\nIn addition, if you combine or link compiled forms of this Software with\nsoftware that is licensed under the GPLv2 (\"Combined Software\") and if a\ncourt of competent jurisdiction determines that the patent provision (Section\n3), the indemnity provision (Section 9) or other Section of the License\nconflicts with the conditions of the GPLv2, you may retroactively and\nprospectively choose to deem waived or otherwise exclude such Section(s) of\nthe License, but only in their entirety and only with respect to the Combined\nSoftware.\n\n==============================================================================\nSoftware from third parties included in the LLVM Project:\n==============================================================================\nThe LLVM Project contains third party software which is under different license\nterms. All such code will be identified clearly using at least one of two\nmechanisms:\n1) It will be in a separate directory tree with its own `LICENSE.txt` or\n   `LICENSE` file at the top containing the specific license and restrictions\n   which apply to that software, or\n2) It will contain specific license and restriction terms at the top of every\n   file.\n\n==============================================================================\nLegacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):\n==============================================================================\n\nThe libc++abi library is dual licensed under both the University of Illinois\n\"BSD-Like\" license and the MIT license.  As a user of this code you may choose\nto use it under either license.  As a contributor, you agree to allow your code\nto be used under both.\n\nFull text of the relevant licenses is included below.\n\n==============================================================================\n\nUniversity of Illinois/NCSA\nOpen Source License\n\nCopyright (c) 2009-2019 by the contributors listed in CREDITS.TXT\n\nAll rights reserved.\n\nDeveloped by:\n\n    LLVM Team\n\n    University of Illinois at Urbana-Champaign\n\n    http://llvm.org\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal with\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\n    * Redistributions of source code must retain the above copyright notice,\n      this list of conditions and the following disclaimers.\n\n    * Redistributions in binary form must reproduce the above copyright notice,\n      this list of conditions and the following disclaimers in the\n      documentation and/or other materials provided with the distribution.\n\n    * Neither the names of the LLVM Team, University of Illinois at\n      Urbana-Champaign, nor the names of its contributors may be used to\n      endorse or promote products derived from this Software without specific\n      prior written permission.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\nFOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\nCONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n\n==============================================================================\n\nCopyright (c) 2009-2014 by the contributors listed in CREDITS.TXT\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-libc--abi-src-license.txt",
-            "name": "NCSA, Apache-with-LLVM-Exception, MIT"
-        },
-        {
-            "extractedText": "libjpeg-turbo Licenses\n======================\n\nlibjpeg-turbo is covered by two compatible BSD-style open source licenses:\n\n- The IJG (Independent JPEG Group) License, which is listed in\n  [README.ijg](README.ijg)\n\n  This license applies to the libjpeg API library and associated programs,\n  including any code inherited from libjpeg and any modifications to that\n  code.  Note that the libjpeg-turbo SIMD source code bears the\n  [zlib License](https://opensource.org/licenses/Zlib), but in the context of\n  the overall libjpeg API library, the terms of the zlib License are subsumed\n  by the terms of the IJG License.\n\n- The Modified (3-clause) BSD License, which is listed below\n\n  This license applies to the TurboJPEG API library and associated programs, as\n  well as the build system.  Note that the TurboJPEG API library wraps the\n  libjpeg API library, so in the context of the overall TurboJPEG API library,\n  both the terms of the IJG License and the terms of the Modified (3-clause)\n  BSD License apply.\n\n\nComplying with the libjpeg-turbo Licenses\n=========================================\n\nThis section provides a roll-up of the libjpeg-turbo licensing terms, to the\nbest of our understanding.  This is not a license in and of itself.  It is\nintended solely for clarification.\n\n1.  If you are distributing a modified version of the libjpeg-turbo source,\n    then:\n\n    1.  You cannot alter or remove any existing copyright or license notices\n        from the source.\n\n        **Origin**\n        - Clause 1 of the IJG License\n        - Clause 1 of the Modified BSD License\n        - Clauses 1 and 3 of the zlib License\n\n    2.  You must add your own copyright notice to the header of each source\n        file you modified, so others can tell that you modified that file.  (If\n        there is not an existing copyright header in that file, then you can\n        simply add a notice stating that you modified the file.)\n\n        **Origin**\n        - Clause 1 of the IJG License\n        - Clause 2 of the zlib License\n\n    3.  You must include the IJG README file, and you must not alter any of the\n        copyright or license text in that file.\n\n        **Origin**\n        - Clause 1 of the IJG License\n\n2.  If you are distributing only libjpeg-turbo binaries without the source, or\n    if you are distributing an application that statically links with\n    libjpeg-turbo, then:\n\n    1.  Your product documentation must include a message stating:\n\n        This software is based in part on the work of the Independent JPEG\n        Group.\n\n        **Origin**\n        - Clause 2 of the IJG license\n\n    2.  If your binary distribution includes or uses the TurboJPEG API, then\n        your product documentation must include the text of the Modified BSD\n        License (see below.)\n\n        **Origin**\n        - Clause 2 of the Modified BSD License\n\n3.  You cannot use the name of the IJG or The libjpeg-turbo Project or the\n    contributors thereof in advertising, publicity, etc.\n\n    **Origin**\n    - IJG License\n    - Clause 3 of the Modified BSD License\n\n4.  The IJG and The libjpeg-turbo Project do not warrant libjpeg-turbo to be\n    free of defects, nor do we accept any liability for undesirable\n    consequences resulting from your use of the software.\n\n    **Origin**\n    - IJG License\n    - Modified BSD License\n    - zlib License\n\n\nThe Modified (3-clause) BSD License\n===================================\n\nCopyright (C)2009-2024 D. R. Commander.  All Rights Reserved.<br>\nCopyright (C)2015 Viktor Szathm\u00e1ry.  All Rights Reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n- Redistributions of source code must retain the above copyright notice,\n  this list of conditions and the following disclaimer.\n- Redistributions in binary form must reproduce the above copyright notice,\n  this list of conditions and the following disclaimer in the documentation\n  and/or other materials provided with the distribution.\n- Neither the name of the libjpeg-turbo Project nor the names of its\n  contributors may be used to endorse or promote products derived from this\n  software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\",\nAND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\nARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE\nLIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\nCONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\nSUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\nINTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\nCONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\nARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\nPOSSIBILITY OF SUCH DAMAGE.\n\n\nWhy Two Licenses?\n=================\n\nThe zlib License could have been used instead of the Modified (3-clause) BSD\nLicense, and since the IJG License effectively subsumes the distribution\nconditions of the zlib License, this would have effectively placed\nlibjpeg-turbo binary distributions under the IJG License.  However, the IJG\nLicense specifically refers to the Independent JPEG Group and does not extend\nattribution and endorsement protections to other entities.  Thus, it was\ndesirable to choose a license that granted us the same protections for new code\nthat were granted to the IJG for code derived from their software.\n",
-            "licenseId": "LicenseRef-third-party-libjpeg-turbo-license.md",
-            "name": "IJG, BSD-3-Clause, Zlib"
         },
         {
             "extractedText": "Copyright (c) 2010, The WebM Project authors. All rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n  * Redistributions of source code must retain the above copyright\n    notice, this list of conditions and the following disclaimer.\n\n  * Redistributions in binary form must reproduce the above copyright\n    notice, this list of conditions and the following disclaimer in\n    the documentation and/or other materials provided with the\n    distribution.\n\n  * Neither the name of Google, nor the WebM Project, nor the names\n    of its contributors may be used to endorse or promote products\n    derived from this software without specific prior written\n    permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nHOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n",
@@ -154,19 +79,9 @@
             "name": "BSD-3-Clause, Patent"
         },
         {
-            "extractedText": "==============================================================================\nThe LLVM Project is under the Apache License v2.0 with LLVM Exceptions:\n==============================================================================\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n    1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n    2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n    3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n    4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n    5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n    6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n    7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n    8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n    9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n    END OF TERMS AND CONDITIONS\n\n    APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n    Copyright [yyyy] [name of copyright owner]\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n\n---- LLVM Exceptions to the Apache 2.0 License ----\n\nAs an exception, if, as a result of your compiling your source code, portions\nof this Software are embedded into an Object form of such source code, you\nmay redistribute such embedded portions in such Object form without complying\nwith the conditions of Sections 4(a), 4(b) and 4(d) of the License.\n\nIn addition, if you combine or link compiled forms of this Software with\nsoftware that is licensed under the GPLv2 (\"Combined Software\") and if a\ncourt of competent jurisdiction determines that the patent provision (Section\n3), the indemnity provision (Section 9) or other Section of the License\nconflicts with the conditions of the GPLv2, you may retroactively and\nprospectively choose to deem waived or otherwise exclude such Section(s) of\nthe License, but only in their entirety and only with respect to the Combined\nSoftware.\n\n==============================================================================\nSoftware from third parties included in the LLVM Project:\n==============================================================================\nThe LLVM Project contains third party software which is under different license\nterms. All such code will be identified clearly using at least one of two\nmechanisms:\n1) It will be in a separate directory tree with its own `LICENSE.txt` or\n   `LICENSE` file at the top containing the specific license and restrictions\n   which apply to that software, or\n2) It will contain specific license and restriction terms at the top of every\n   file.\n\n==============================================================================\nLegacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):\n==============================================================================\nUniversity of Illinois/NCSA\nOpen Source License\n\nCopyright (c) 2007-2019 University of Illinois at Urbana-Champaign.\nAll rights reserved.\n\nDeveloped by:\n\n    LLVM Team\n\n    University of Illinois at Urbana-Champaign\n\n    http://llvm.org\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of\nthis software and associated documentation files (the \"Software\"), to deal with\nthe Software without restriction, including without limitation the rights to\nuse, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\nof the Software, and to permit persons to whom the Software is furnished to do\nso, subject to the following conditions:\n\n    * Redistributions of source code must retain the above copyright notice,\n      this list of conditions and the following disclaimers.\n\n    * Redistributions in binary form must reproduce the above copyright notice,\n      this list of conditions and the following disclaimers in the\n      documentation and/or other materials provided with the distribution.\n\n    * Neither the names of the LLVM Team, University of Illinois at\n      Urbana-Champaign, nor the names of its contributors may be used to\n      endorse or promote products derived from this Software without specific\n      prior written permission.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\nFOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\nCONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-llvm-libc-src-license.txt",
-            "name": "MIT, NCSA"
-        },
-        {
             "extractedText": "Copyright 2001-2023 Xiph.Org, Skype Limited, Octasic,\n                    Jean-Marc Valin, Timothy B. Terriberry,\n                    CSIRO, Gregory Maxwell, Mark Borgerding,\n                    Erik de Castro Lopo, Mozilla, Amazon\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n- Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n\n- Redistributions in binary form must reproduce the above copyright\nnotice, this list of conditions and the following disclaimer in the\ndocumentation and/or other materials provided with the distribution.\n\n- Neither the name of Internet Society, IETF or IETF Trust, nor the\nnames of specific contributors, may be used to endorse or promote\nproducts derived from this software without specific prior written\npermission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER\nOR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\nPROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR\nPROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF\nLIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\nNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\nOpus is subject to the royalty-free patent licenses which are\nspecified at:\n\nXiph.Org Foundation:\nhttps://datatracker.ietf.org/ipr/1524/\n\nMicrosoft Corporation:\nhttps://datatracker.ietf.org/ipr/1914/\n\nBroadcom Corporation:\nhttps://datatracker.ietf.org/ipr/1526/\n",
             "licenseId": "LicenseRef-third-party-opus-src-copying",
             "name": "Opus-Patent-BSD-3-Clause"
-        },
-        {
-            "extractedText": "// Copyright 2014 The PDFium Authors\n//\n// Redistribution and use in source and binary forms, with or without\n// modification, are permitted provided that the following conditions are\n// met:\n//\n//    * Redistributions of source code must retain the above copyright\n// notice, this list of conditions and the following disclaimer.\n//    * Redistributions in binary form must reproduce the above\n// copyright notice, this list of conditions and the following disclaimer\n// in the documentation and/or other materials provided with the\n// distribution.\n//    * Neither the name of Google Inc. nor the names of its\n// contributors may be used to endorse or promote products derived from\n// this software without specific prior written permission.\n//\n// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n// \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        https://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       https://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n",
-            "licenseId": "LicenseRef-third-party-pdfium-license",
-            "name": "BSD"
         },
         {
             "extractedText": "\n                            C++ Big Integer Library\n                          (see ChangeLog for version)\n\n                        http://mattmccutchen.net/bigint/\n\n       Written and maintained by Matt McCutchen <matt@mattmccutchen.net>\n\nYou can use this library in a C++ program to do arithmetic on integers of size\nlimited only by your computer's memory.  The library provides BigUnsigned and\nBigInteger classes that represent nonnegative integers and signed integers,\nrespectively.  Most of the C++ arithmetic operators are overloaded for these\nclasses, so big-integer calculations are as easy as:\n\n    #include \"BigIntegerLibrary.hh\"\n    \n    BigInteger a = 65536;\n    cout << (a * a * a * a * a * a * a * a);\n    \n    (prints 340282366920938463463374607431768211456)\n\nThe code in `sample.cc' demonstrates the most important features of the library.\nTo get started quickly, read the code and explanations in that file and run it.\nIf you want more detail or a feature not shown in `sample.cc', consult the\nconsult the actual header and source files, which are thoroughly commented.\n\nThis library emphasizes ease of use and clarity of implementation over speed;\nsome users will prefer GMP (http://swox.com/gmp/), which is faster.  The code is\nintended to be reasonably portable across computers and modern C++ compilers; in\nparticular, it uses whatever word size the computer provides (32-bit, 64-bit, or\notherwise).\n\nCompiling programs that use the library\n---------------------------------------\nThe library consists of a folder full of C++ header files (`.hh') and source\nfiles (`.cc').  Your own programs should `#include' the necessary header files\nand link with the source files.  A makefile that builds the sample program\n(`sample.cc') is included; you can adapt it to replace the sample with your own\nprogram.\n\nAlternatively, you can use your own build system or IDE.  In that case, you must\nput the library header files where the compiler will find them and arrange to\nhave your program linked with the library source files; otherwise, you will get\nerrors about missing header files or \"undefined references\".  To learn how to do\nthis, consult the documentation for the build system or IDE; don't bother asking\nme.  Adding all the library files to your project will work in many IDEs but may\nnot be the most desirable approach.\n\nResources\n---------\nThe library's Web site (above) provides links to released versions, the current\ndevelopment version, and a mailing list for release announcements, questions,\nbug reports, and other discussion of the library.  I would be delighted to hear\nfrom you if you like this library and/or find a good use for it.\n\nBugs and enhancements\n---------------------\nThe library has been tested by me and others but is by no means bug-free.  If\nyou find a bug, please report it, whether it comes in the form of compiling\ntrouble, a mathematically inaccurate result, or a memory-management blooper\n(since I use Java, these are altogether too common in my C++).  I generally fix\nall reported bugs.  You are also welcome to request enhancements, but I am\nunlikely to do substantial amounts of work on enhancements at this point.\n\nLegal\n-----\nI, Matt McCutchen, the sole author of the original Big Integer Library, waive my\ncopyright to it, placing it in the public domain.  The library comes with\nabsolutely no warranty.\n\n~~~~\n",
@@ -174,44 +89,9 @@
             "name": "Public domain"
         },
         {
-            "extractedText": "                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n------------------\n\nFiles: * except those files noted below\n\n   Copyright (c) 2017, The Android Open Source Project\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n\n------------------\n\nFiles: src/trace_processor/perfetto_sql/stdlib/chromium/*, protos/third_party/chromium/*, test/trace_processor/diff_tests/stdlib/chrome/*\n\n   Copyright 2015 The Chromium Authors\n\n   Redistribution and use in source and binary forms, with or without\n   modification, are permitted provided that the following conditions are\n   met:\n\n      * Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer.\n      * Redistributions in binary form must reproduce the above\n   copyright notice, this list of conditions and the following disclaimer\n   in the documentation and/or other materials provided with the\n   distribution.\n      * Neither the name of Google LLC nor the names of its\n   contributors may be used to endorse or promote products derived from\n   this software without specific prior written permission.\n\n   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n   \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n\n------------------\n\nFiles: src/trace_processor/perfetto_sql/preprocessor/preprocessor_grammar.{c, h}\n\nThe author disclaims copyright to this source code. In place of a legal notice, here is a blessing:\n\nMay you do good and not evil.\nMay you find forgiveness for yourself and forgive others.\nMay you share freely, never taking more than you give.\n\n\n------------------\n\nFiles: src/base/intrusive_tree.cc\n\n$OpenBSD: tree.h,v 1.31 2023/03/08 04:43:09 guenther Exp $\n\nCopyright 2002 Niels Provos <provos@citi.umich.edu>\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer.\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in the\n   documentation and/or other materials provided with the distribution.\n\nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\nIMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\nIN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\nINCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\nNOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\nTHIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-third-party-perfetto-license",
-            "name": "blessing, BSD-3-Clause, Apache-2.0"
-        },
-        {
             "extractedText": "Copyright (c) 2013  Julien Pommier ( pommier@modartt.com )\n\nBased on original fortran 77 code from FFTPACKv4 from NETLIB,\nauthored by Dr Paul Swarztrauber of NCAR, in 1985.\n\nAs confirmed by the NCAR fftpack software curators, the following\nFFTPACKv5 license applies to FFTPACKv4 sources. My changes are\nreleased under the same terms.\n\nFFTPACK license:\n\nhttp://www.cisl.ucar.edu/css/software/fftpack5/ftpk.html\n\nCopyright (c) 2004 the University Corporation for Atmospheric\nResearch (\"UCAR\"). All rights reserved. Developed by NCAR's\nComputational and Information Systems Laboratory, UCAR,\nwww.cisl.ucar.edu.\n\nRedistribution and use of the Software in source and binary forms,\nwith or without modification, is permitted provided that the\nfollowing conditions are met:\n\n- Neither the names of NCAR's Computational and Information Systems\nLaboratory, the University Corporation for Atmospheric Research,\nnor the names of its sponsors or contributors may be used to\nendorse or promote products derived from this Software without\nspecific prior written permission.\n\n- Redistributions of source code must retain the above copyright\nnotices, this list of conditions, and the disclaimer below.\n\n- Redistributions in binary form must reproduce the above copyright\nnotice, this list of conditions, and the disclaimer below in the\ndocumentation and/or other materials provided with the\ndistribution.\n\nTHIS SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT\nHOLDERS BE LIABLE FOR ANY CLAIM, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY, WHETHER IN AN\nACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN\nCONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE\nSOFTWARE.\n",
             "licenseId": "LicenseRef-third-party-pffft-license",
             "name": "pffft"
-        },
-        {
-            "extractedText": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n",
-            "licenseId": "LicenseRef-third-party-rust-chromium-crates-io-vendor-encoding-rs-v0-8-license-apache",
-            "name": "Apache-2.0, BSD-3-Clause"
-        },
-        {
-            "extractedText": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n",
-            "licenseId": "LicenseRef-third-party-rust-chromium-crates-io-vendor-unicode-ident-v1-license-apache",
-            "name": "Apache-2.0, Unicode-3.0"
-        },
-        {
-            "extractedText": "UNICODE LICENSE V3\n\nCOPYRIGHT AND PERMISSION NOTICE\n\nCopyright \u00a9 1991-2023 Unicode, Inc.\n\nNOTICE TO USER: Carefully read the following legal agreement. BY\nDOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR\nSOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE\nTERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT\nDOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of data files and any associated documentation (the \"Data Files\") or\nsoftware and any associated documentation (the \"Software\") to deal in the\nData Files or Software without restriction, including without limitation\nthe rights to use, copy, modify, merge, publish, distribute, and/or sell\ncopies of the Data Files or Software, and to permit persons to whom the\nData Files or Software are furnished to do so, provided that either (a)\nthis copyright and permission notice appear with all copies of the Data\nFiles or Software, or (b) this copyright and permission notice appear in\nassociated Documentation.\n\nTHE DATA FILES AND SOFTWARE ARE PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY\nKIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF\nTHIRD PARTY RIGHTS.\n\nIN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE\nBE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,\nOR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,\nWHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,\nARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA\nFILES OR SOFTWARE.\n\nExcept as contained in this notice, the name of a copyright holder shall\nnot be used in advertising or otherwise to promote the sale, use or other\ndealings in these Data Files or Software without prior written\nauthorization of the copyright holder.\n",
-            "licenseId": "LicenseRef-third-party-rust-chromium-crates-io-vendor-unicode-ident-v1-license-unicode",
-            "name": "Apache-2.0, Unicode-3.0"
-        },
-        {
-            "extractedText": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n-------------------------------------------------------------------------------\n\nCopyright (c) 2008-2011, Susumu Yata All rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n- Redistributions of source code must retain the above copyright notice, this\nlist of conditions and the following disclaimer.  - Redistributions in binary\nform must reproduce the above copyright notice, this list of conditions and the\nfollowing disclaimer in the documentation and/or other materials provided with\nthe distribution.  - Neither the name of the <ORGANIZATION> nor the names of\nits contributors may be used to endorse or promote products derived from this\nsoftware without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR\nANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\nLOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON\nANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n-------------------------------------------------------------------------------\n\nThis is the esaxx copyright.\n\nCopyright (c) 2010 Daisuke Okanohara All Rights Reserved.\n\nPermission is hereby granted, free of charge, to any person\nobtaining a copy of this software and associated documentation\nfiles (the \"Software\"), to deal in the Software without\nrestriction, including without limitation the rights to use,\ncopy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the\nSoftware is furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES\nOF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT\nHOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,\nWHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\nFROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\nOTHER DEALINGS IN THE SOFTWARE.\n\n-------------------------------------------------------------------------------\n\n\nCopyright 2008 Google Inc.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\nCode generated by the Protocol Buffer compiler is owned by the owner\nof the input file used when generating it.  This code is not\nstandalone and requires a support library to be linked with it.  This\nsupport library is itself covered by the above license.\n",
-            "licenseId": "LicenseRef-third-party-sentencepiece-license",
-            "name": "BSD-3-Clause, Apache-2.0, MIT"
-        },
-        {
-            "extractedText": "All MurmurHash source files are placed in the public domain.\n\nThe license below applies to all other code in SMHasher:\n\nCopyright (c) 2011 Google, Inc.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
-            "licenseId": "LicenseRef-third-party-smhasher-license",
-            "name": "MIT, Unlicense"
-        },
-        {
-            "extractedText": "Copyright 2011, Google Inc.\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\nnotice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\ncopyright notice, this list of conditions and the following disclaimer\nin the documentation and/or other materials provided with the\ndistribution.\n    * Neither the name of Google Inc. nor the names of its\ncontributors may be used to endorse or promote products derived from\nthis software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n===\n\nSome of the benchmark data in testdata/ is licensed differently:\n\n - fireworks.jpeg is Copyright 2013 Steinar H. Gunderson, and\n   is licensed under the Creative Commons Attribution 3.0 license\n   (CC-BY-3.0). See https://creativecommons.org/licenses/by/3.0/\n   for more information.\n\n - kppkn.gtb is taken from the Gaviota chess tablebase set, and\n   is licensed under the MIT License. See\n   https://sites.google.com/site/gaviotachessengine/Home/endgame-tablebases-1\n   for more information.\n\n - paper-100k.pdf is an excerpt (bytes 92160 to 194560) from the paper\n   \u201cCombinatorial Modeling of Chromatin Features Quantitatively Predicts DNA\n   Replication Timing in _Drosophila_\u201d by Federico Comoglio and Renato Paro,\n   which is licensed under the CC-BY license. See\n   http://www.ploscompbiol.org/static/license for more ifnormation.\n\n - alice29.txt, asyoulik.txt, plrabn12.txt and lcet10.txt are from Project\n   Gutenberg. The first three have expired copyrights and are in the public\n   domain; the latter does not have expired copyright, but is still in the\n   public domain according to the license information\n   (http://www.gutenberg.org/ebooks/53).\n",
-            "licenseId": "LicenseRef-third-party-snappy-src-copying",
-            "name": "BSD-3-Clause, CC-BY-4.0, MIT, CC-BY-3.0"
         },
         {
             "extractedText": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n",
@@ -239,11 +119,6 @@
             "name": "UnRAR"
         },
         {
-            "extractedText": "MIT License\n\n\u00a9 2012-2016 Connor Lane Smith <cls@lubutu.com>\n\u00a9 2015 Laslo Hunhold <dev@frign.de>\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the \"Software\"),\nto deal in the Software without restriction, including without limitation\nthe rights to use, copy, modify, merge, publish, distribute, sublicense,\nand/or sell copies of the Software, and to permit persons to whom the\nSoftware is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL\nTHE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\nFROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n\n--------------------------------------------------------------------------\n\nThe 'UnicodeData-9.0.0.txt' file is from the Unicode Character Database.\nIt is available at http://www.unicode.org/Public/zipped/9.0.0/UCD.zip and\nis made available under the following license by Unicode, Inc:\n\nCOPYRIGHT AND PERMISSION NOTICE\n\nCopyright \u00a9 1991-2016 Unicode, Inc. All rights reserved.\nDistributed under the Terms of Use in\nhttp://www.unicode.org/copyright.html.\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of the Unicode data files and any associated documentation\n(the \"Data Files\") or Unicode software and any associated documentation\n(the \"Software\") to deal in the Data Files or Software\nwithout restriction, including without limitation the rights to use,\ncopy, modify, merge, publish, distribute, and/or sell copies of\nthe Data Files or Software, and to permit persons to whom the Data Files\nor Software are furnished to do so, provided that\n(a) this copyright and permission notice appear with all copies\nof the Data Files or Software,\n(b) this copyright and permission notice appear in associated\ndocumentation, and\n(c) there is clear notice in each modified Data File or in the Software\nas well as in the documentation associated with the Data File(s) or\nSoftware that the data or software has been modified.\n\nTHE DATA FILES AND SOFTWARE ARE PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE\nWARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT OF THIRD PARTY RIGHTS.\nIN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS\nNOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL\nDAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,\nDATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER\nTORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR\nPERFORMANCE OF THE DATA FILES OR SOFTWARE.\n\nExcept as contained in this notice, the name of a copyright holder\nshall not be used in advertising or otherwise to promote the sale,\nuse or other dealings in these Data Files or Software without prior\nwritten authorization of the copyright holder.",
-            "licenseId": "LicenseRef-third-party-utf-license",
-            "name": "Unicode-DFS-2015, MIT"
-        },
-        {
             "extractedText": "/*\n * http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html\n * Copyright Takuya OOURA, 1996-2001\n *\n * You may use, copy, modify and distribute this code for any purpose (include\n * commercial use) and without fee. Please refer to this package when you modify\n * this code.\n */\n",
             "licenseId": "LicenseRef-third-party-webrtc-common-audio-third-party-ooura-license",
             "name": "LicenseRef-takuya-ooura"
@@ -269,26 +144,6 @@
             "name": "Custom license"
         },
         {
-            "extractedText": "This license applies to all parts of V8 that are not externally\nmaintained libraries.  The externally maintained libraries used by V8\nare:\n\n  - PCRE test suite, located in\n    test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the\n    test suite from PCRE-7.3, which is copyrighted by the University\n    of Cambridge and Google, Inc.  The copyright notice and license\n    are embedded in regexp-pcre.js.\n\n  - Layout tests, located in test/mjsunit/third_party/object-keys.  These are\n    based on layout tests from webkit.org which are copyrighted by\n    Apple Computer, Inc. and released under a 3-clause BSD license.\n\n  - Strongtalk assembler, the basis of the files assembler-arm-inl.h,\n    assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,\n    assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,\n    assembler-x64.cc, assembler-x64.h, assembler.cc and assembler.h.\n    This code is copyrighted by Sun Microsystems Inc. and released\n    under a 3-clause BSD license.\n\n  - Valgrind client API header, located at third_party/valgrind/valgrind.h\n    This is released under the BSD license.\n\n  - The Wasm C/C++ API headers, located at third_party/wasm-api/wasm.{h,hh}\n    This is released under the Apache license. The API's upstream prototype\n    implementation also formed the basis of V8's implementation in\n    src/wasm/c-api.cc.\n\nThese libraries have their own licenses; we recommend you read them,\nas their terms may differ from the terms below.\n\nFurther license information can be found in LICENSE files located in\nsub-directories.\n\nCopyright 2014, the V8 project authors. All rights reserved.\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\n      notice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\n      copyright notice, this list of conditions and the following\n      disclaimer in the documentation and/or other materials provided\n      with the distribution.\n    * Neither the name of Google Inc. nor the names of its\n      contributors may be used to endorse or promote products derived\n      from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-v8-license",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "Copyright (C) 1993-2004 by Sun Microsystems, Inc. All rights reserved.\n\nDeveloped at SunSoft, a Sun Microsystems, Inc. business.\nPermission to use, copy, modify, and distribute this\nsoftware is freely granted, provided that this notice\nis preserved.\n",
-            "licenseId": "LicenseRef-v8-license.fdlibm",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "Copyright (c) 1994-2006 Sun Microsystems Inc.\nAll Rights Reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n- Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n- Redistribution in binary form must reproduce the above copyright\nnotice, this list of conditions and the following disclaimer in the\ndocumentation and/or other materials provided with the distribution.\n\n- Neither the name of Sun Microsystems or the names of contributors may\nbe used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS\nIS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,\nTHE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR\nCONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\nEXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\nPROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR\nPROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF\nLIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\nNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-v8-license.strongtalk",
-            "name": "BSD"
-        },
-        {
-            "extractedText": "Copyright 2006-2011, the V8 project authors. All rights reserved.\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are\nmet:\n\n    * Redistributions of source code must retain the above copyright\n      notice, this list of conditions and the following disclaimer.\n    * Redistributions in binary form must reproduce the above\n      copyright notice, this list of conditions and the following\n      disclaimer in the documentation and/or other materials provided\n      with the distribution.\n    * Neither the name of Google Inc. nor the names of its\n      contributors may be used to endorse or promote products derived\n      from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\nLIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\nA PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\nOWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-            "licenseId": "LicenseRef-v8-license.v8",
-            "name": "BSD"
-        },
-        {
             "extractedText": "CC0 1.0 Universal\n\nStatement of Purpose\n\nThe laws of most jurisdictions throughout the world automatically confer\nexclusive Copyright and Related Rights (defined below) upon the creator and\nsubsequent owner(s) (each and all, an \"owner\") of an original work of\nauthorship and/or a database (each, a \"Work\").\n\nCertain owners wish to permanently relinquish those rights to a Work for the\npurpose of contributing to a commons of creative, cultural and scientific\nworks (\"Commons\") that the public can reliably and without fear of later\nclaims of infringement build upon, modify, incorporate in other works, reuse\nand redistribute as freely as possible in any form whatsoever and for any\npurposes, including without limitation commercial purposes. These owners may\ncontribute to the Commons to promote the ideal of a free culture and the\nfurther production of creative, cultural and scientific works, or to gain\nreputation or greater distribution for their Work in part through the use and\nefforts of others.\n\nFor these and/or other purposes and motivations, and without any expectation\nof additional consideration or compensation, the person associating CC0 with a\nWork (the \"Affirmer\"), to the extent that he or she is an owner of Copyright\nand Related Rights in the Work, voluntarily elects to apply CC0 to the Work\nand publicly distribute the Work under its terms, with knowledge of his or her\nCopyright and Related Rights in the Work and the meaning and intended legal\neffect of CC0 on those rights.\n\n1. Copyright and Related Rights. A Work made available under CC0 may be\nprotected by copyright and related or neighboring rights (\"Copyright and\nRelated Rights\"). Copyright and Related Rights include, but are not limited\nto, the following:\n\n  i. the right to reproduce, adapt, distribute, perform, display, communicate,\n  and translate a Work;\n\n  ii. moral rights retained by the original author(s) and/or performer(s);\n\n  iii. publicity and privacy rights pertaining to a person's image or likeness\n  depicted in a Work;\n\n  iv. rights protecting against unfair competition in regards to a Work,\n  subject to the limitations in paragraph 4(a), below;\n\n  v. rights protecting the extraction, dissemination, use and reuse of data in\n  a Work;\n\n  vi. database rights (such as those arising under Directive 96/9/EC of the\n  European Parliament and of the Council of 11 March 1996 on the legal\n  protection of databases, and under any national implementation thereof,\n  including any amended or successor version of such directive); and\n\n  vii. other similar, equivalent or corresponding rights throughout the world\n  based on applicable law or treaty, and any national implementations thereof.\n\n2. Waiver. To the greatest extent permitted by, but not in contravention of,\napplicable law, Affirmer hereby overtly, fully, permanently, irrevocably and\nunconditionally waives, abandons, and surrenders all of Affirmer's Copyright\nand Related Rights and associated claims and causes of action, whether now\nknown or unknown (including existing as well as future claims and causes of\naction), in the Work (i) in all territories worldwide, (ii) for the maximum\nduration provided by applicable law or treaty (including future time\nextensions), (iii) in any current or future medium and for any number of\ncopies, and (iv) for any purpose whatsoever, including without limitation\ncommercial, advertising or promotional purposes (the \"Waiver\"). Affirmer makes\nthe Waiver for the benefit of each member of the public at large and to the\ndetriment of Affirmer's heirs and successors, fully intending that such Waiver\nshall not be subject to revocation, rescission, cancellation, termination, or\nany other legal or equitable action to disrupt the quiet enjoyment of the Work\nby the public as contemplated by Affirmer's express Statement of Purpose.\n\n3. Public License Fallback. Should any part of the Waiver for any reason be\njudged legally invalid or ineffective under applicable law, then the Waiver\nshall be preserved to the maximum extent permitted taking into account\nAffirmer's express Statement of Purpose. In addition, to the extent the Waiver\nis so judged Affirmer hereby grants to each affected person a royalty-free,\nnon transferable, non sublicensable, non exclusive, irrevocable and\nunconditional license to exercise Affirmer's Copyright and Related Rights in\nthe Work (i) in all territories worldwide, (ii) for the maximum duration\nprovided by applicable law or treaty (including future time extensions), (iii)\nin any current or future medium and for any number of copies, and (iv) for any\npurpose whatsoever, including without limitation commercial, advertising or\npromotional purposes (the \"License\"). The License shall be deemed effective as\nof the date CC0 was applied by Affirmer to the Work. Should any part of the\nLicense for any reason be judged legally invalid or ineffective under\napplicable law, such partial invalidity or ineffectiveness shall not\ninvalidate the remainder of the License, and in such case Affirmer hereby\naffirms that he or she will not (i) exercise any of his or her remaining\nCopyright and Related Rights in the Work or (ii) assert any associated claims\nand causes of action with respect to the Work, in either case contrary to\nAffirmer's express Statement of Purpose.\n\n4. Limitations and Disclaimers.\n\n  a. No trademark or patent rights held by Affirmer are waived, abandoned,\n  surrendered, licensed or otherwise affected by this document.\n\n  b. Affirmer offers the Work as-is and makes no representations or warranties\n  of any kind concerning the Work, express, implied, statutory or otherwise,\n  including without limitation warranties of title, merchantability, fitness\n  for a particular purpose, non infringement, or the absence of latent or\n  other defects, accuracy, or the present or absence of errors, whether or not\n  discoverable, all to the greatest extent permissible under applicable law.\n\n  c. Affirmer disclaims responsibility for clearing rights of other persons\n  that may apply to the Work or any use thereof, including without limitation\n  any person's Copyright and Related Rights in the Work. Further, Affirmer\n  disclaims responsibility for obtaining any necessary consents, permissions\n  or other rights required for any use of the Work.\n\n  d. Affirmer understands and acknowledges that Creative Commons is not a\n  party to this document and has no duty or obligation with respect to this\n  CC0 or use of the Work.\n\nFor more information, please see\n<http://creativecommons.org/publicdomain/zero/1.0/>\n",
             "licenseId": "LicenseRef-v8-third-party-siphash-license",
             "name": "Public domain"
@@ -306,66 +161,144 @@
     ],
     "name": "Chromium-licenses",
     "spdxVersion": "SPDX-2.3",
-    "documentNamespace": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/",
+    "documentNamespace": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/1.1/",
     "packages": [
         {
+            "SPDXID": "SPDXRef-Package-Chromium",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "https://www.chromium.org/",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/LICENSE",
+                    "referenceType": "url"
+                }
+            ],
+            "filesAnalyzed": false,
+            "homepage": "https://www.chromium.org/",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Chromium",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "148.0.7778.97"
+        },
+        {
             "SPDXID": "SPDXRef-Package-CityHash",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/cityhash",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/base/third_party/cityhash/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/cityhash@1.1.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/cityhash",
             "licenseConcluded": "MIT",
-            "name": "CityHash"
+            "licenseDeclared": "MIT",
+            "name": "CityHash",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 8af9b8c",
+            "versionInfo": "1.1.1"
         },
         {
             "SPDXID": "SPDXRef-Package-CityHash-1",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/cityhash",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/base/third_party/cityhash_v103/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/cityhash@1.0.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/cityhash",
             "licenseConcluded": "MIT",
-            "name": "CityHash"
+            "licenseDeclared": "MIT",
+            "name": "CityHash",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 00b9287e8c1255b5922ef90e304d5287361b2c2a",
+            "versionInfo": "1.0.3"
         },
         {
             "SPDXID": "SPDXRef-Package-Google-Double-Conversion",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/double-conversion",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/base/third_party/double_conversion/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/double-conversion@32bc443c60c860eb6b4843533a614766d611172e",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/double-conversion",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Google Double Conversion"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Google Double Conversion",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "32bc443c60c860eb6b4843533a614766d611172e"
         },
         {
             "SPDXID": "SPDXRef-Package-Netscape-Portable-Runtime--NSPR-",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://hg.mozilla.org/projects/nspr",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/base/third_party/nspr/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:2.3:a:mozilla:netscape_portable_runtime:4.38.2:*:*:*:*:*:*:*",
+                    "referenceType": "cpe23Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://hg.mozilla.org/projects/nspr",
             "licenseConcluded": "MPL-2.0",
-            "name": "Netscape Portable Runtime (NSPR)"
+            "licenseDeclared": "MPL-2.0",
+            "name": "Netscape Portable Runtime (NSPR)",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 488a7a069c8d7405696fd8171ec8fc369834158b",
+            "versionInfo": "4.38.2"
         },
         {
             "SPDXID": "SPDXRef-Package-Paul-Hsieh-s-SuperFastHash",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.azillionmonkeys.com/qed/hash.html",
             "externalRefs": [
                 {
@@ -374,26 +307,46 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://www.azillionmonkeys.com/qed/hash.html",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Paul Hsieh's SuperFastHash"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Paul Hsieh's SuperFastHash",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-google-glog-s-symbolization-library",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/glog",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/base/third_party/symbolize/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/glog@130a3e1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/glog",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "google-glog's symbolization library"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "google-glog's symbolization library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "130a3e1"
         },
         {
             "SPDXID": "SPDXRef-Package-xdg-user-dirs",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://gitlab.freedesktop.org/xdg/xdg-user-dirs",
             "externalRefs": [
                 {
@@ -402,12 +355,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://gitlab.freedesktop.org/xdg/xdg-user-dirs",
             "licenseConcluded": "MIT",
-            "name": "xdg-user-dirs"
+            "licenseDeclared": "MIT",
+            "name": "xdg-user-dirs",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "2f28f353ec3cf9288da70bab3ca963f2144808f0"
         },
         {
             "SPDXID": "SPDXRef-Package-Mozilla-Personal-Security-Manager",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://dxr.mozilla.org/mozilla1.9.2/source/security/manager/",
             "externalRefs": [
                 {
@@ -416,12 +377,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://dxr.mozilla.org/mozilla1.9.2/source/security/manager/",
             "licenseConcluded": "MPL-1.1",
-            "name": "Mozilla Personal Security Manager"
+            "licenseDeclared": "MPL-1.1",
+            "name": "Mozilla Personal Security Manager",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "Mozilla 1.9.2"
         },
         {
             "SPDXID": "SPDXRef-Package-Mozilla-Windows-Cert-code",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://searchfox.org/mozilla-central/rev/0fec57c05d3996cc00c55a66f20dd5793a9bfb5d/security/manager/ssl/EnterpriseRoots.cpp",
             "externalRefs": [
                 {
@@ -430,12 +399,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://searchfox.org/mozilla-central/rev/0fec57c05d3996cc00c55a66f20dd5793a9bfb5d/security/manager/ssl/EnterpriseRoots.cpp",
             "licenseConcluded": "MPL-2.0",
-            "name": "Mozilla Windows Cert code"
+            "licenseDeclared": "MPL-2.0",
+            "name": "Mozilla Windows Cert code",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "0fec57c05d3996cc00c55a66f20dd5793a9bfb5d"
         },
         {
             "SPDXID": "SPDXRef-Package-QUICHE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://quiche.googlesource.com/quiche",
             "externalRefs": [
                 {
@@ -444,40 +421,72 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://quiche.googlesource.com/quiche",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "QUICHE"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "QUICHE",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 21ffbe4c7b717d00d2d768c259b5b330fd754ac3",
+            "versionInfo": "git"
         },
         {
             "SPDXID": "SPDXRef-Package-URI-Template-Parser",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/google-api-cpp-client/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/net/third_party/uri_template/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/google-api-cpp-client@d0bbe169d81a50936ec5fcea4e6dbcfb97303f13",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/google-api-cpp-client/",
             "licenseConcluded": "Apache-2.0",
-            "name": "URI Template Parser"
+            "licenseDeclared": "Apache-2.0",
+            "name": "URI Template Parser",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "d0bbe169d81a50936ec5fcea4e6dbcfb97303f13"
         },
         {
             "SPDXID": "SPDXRef-Package-Abseil",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/abseil/abseil-cpp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/abseil-cpp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/abseil/abseil-cpp@04f3bc01d12cf58c90a1bb68990f087fa3c3ed19",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/abseil/abseil-cpp",
             "licenseConcluded": "Apache-2.0",
-            "name": "Abseil"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Abseil",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "04f3bc01d12cf58c90a1bb68990f087fa3c3ed19"
         },
         {
             "SPDXID": "SPDXRef-Package-Almost-Native-Graphics-Layer-Engine",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/angle/angle/",
             "externalRefs": [
                 {
@@ -486,28 +495,47 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-angle-license"
-            ],
-            "name": "Almost Native Graphics Layer Engine"
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/angle/angle/",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Almost Native Graphics Layer Engine",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-xxHash",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/Cyan4973/xxHash",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/angle/src/common/third_party/xxhash/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/cyan4973/xxhash@0.8.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/Cyan4973/xxHash",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "xxHash"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "xxHash",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e626a72bc2321cd320e953a0ccf1584cad60f363",
+            "versionInfo": "0.8.3"
         },
         {
             "SPDXID": "SPDXRef-Package-NVidia-Control-X-Extension-Library",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://cgit.freedesktop.org/~aplattner/nvidia-settings/",
             "externalRefs": [
                 {
@@ -516,54 +544,99 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://cgit.freedesktop.org/~aplattner/nvidia-settings/",
             "licenseConcluded": "MIT",
-            "name": "NVidia Control X Extension Library"
+            "licenseDeclared": "MIT",
+            "name": "NVidia Control X Extension Library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "ffa5183362ed4ace5b1cfd031a272f72e7d68c1b"
         },
         {
             "SPDXID": "SPDXRef-Package-Volk-Meta-loader-for-Vulkan-API",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/zeux/volk",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/angle/src/third_party/volk/LICENSE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/zeux/volk@9767549a8bba5454555764ee0f3319bc5d205da9",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/zeux/volk",
             "licenseConcluded": "MIT",
-            "name": "Volk Meta loader for Vulkan API"
+            "licenseDeclared": "MIT",
+            "name": "Volk Meta loader for Vulkan API",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "9767549a8bba5454555764ee0f3319bc5d205da9"
         },
         {
             "SPDXID": "SPDXRef-Package-Anonymous-Tokens",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/anonymous-tokens",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/anonymous_tokens/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/anonymous-tokens@fdff40da0398d2c229308aed169345f6ff1a150f",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/anonymous-tokens",
             "licenseConcluded": "Apache-2.0",
-            "name": "Anonymous Tokens"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Anonymous Tokens",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "fdff40da0398d2c229308aed169345f6ff1a150f"
         },
         {
             "SPDXID": "SPDXRef-Package-AXE-CORE-Accessibility-Audit",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/dequelabs/axe-core/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/axe-core/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/dequelabs/axe-core@3.3.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/dequelabs/axe-core/",
             "licenseConcluded": "MPL-2.0",
-            "name": "AXE-CORE Accessibility Audit"
+            "licenseDeclared": "MPL-2.0",
+            "name": "AXE-CORE Accessibility Audit",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 281653df3794f429b71327fe3afa37ca0fadb1c7",
+            "versionInfo": "3.3.2"
         },
         {
             "SPDXID": "SPDXRef-Package-WebKit",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://webkit.org/",
             "externalRefs": [
                 {
@@ -572,158 +645,298 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-blink-license-for-about-credits"
-            ],
-            "name": "WebKit"
+            "filesAnalyzed": false,
+            "homepage": "https://webkit.org/",
+            "licenseConcluded": "BSD-3-Clause AND LGPL-2.0-only AND LGPL-2.1-only",
+            "licenseDeclared": "BSD-3-Clause AND LGPL-2.0-only AND LGPL-2.1-only",
+            "name": "WebKit",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-BoringSSL",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://boringssl.googlesource.com/boringssl",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/boringssl/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:boringssl",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-boringssl-src-license"
-            ],
-            "name": "BoringSSL"
+            "filesAnalyzed": false,
+            "homepage": "https://boringssl.googlesource.com/boringssl",
+            "licenseConcluded": "LicenseRef-third-party-boringssl-src-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "BoringSSL",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "git"
         },
         {
             "SPDXID": "SPDXRef-Package-Fiat-Crypto--Synthesizing-Correct-by-Construction-Code-for-Cryptographic-Primitives",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/mit-plv/fiat-crypto",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/boringssl/src/third_party/fiat/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/mit-plv/fiat-crypto",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/mit-plv/fiat-crypto",
             "licenseConcluded": "Apache-2.0",
-            "name": "Fiat-Crypto: Synthesizing Correct-by-Construction Code for Cryptographic Primitives"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Fiat-Crypto: Synthesizing Correct-by-Construction Code for Cryptographic Primitives",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6ccc6638716d4632304baf1adbb5c47c3a12ea6f",
+            "versionInfo": "git (see METADATA)"
         },
         {
             "SPDXID": "SPDXRef-Package-Brotli",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/brotli",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/brotli/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/brotli@cfa184a997ac19454d5a3ae97f6d600aac2445a6",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:brotli",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/brotli",
             "licenseConcluded": "MIT",
-            "name": "Brotli"
+            "licenseDeclared": "MIT",
+            "name": "Brotli",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "cfa184a997ac19454d5a3ae97f6d600aac2445a6"
         },
         {
             "SPDXID": "SPDXRef-Package-Compact-Encoding-Detection",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/compact_enc_det",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/ced/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/compact_enc_det@2f40a850bcc5d6f7c1bfa02dbf42ad19d8220dc0",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:ced_project:ced",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/compact_enc_det",
             "licenseConcluded": "Apache-2.0",
-            "name": "Compact Encoding Detection"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Compact Encoding Detection",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "2f40a850bcc5d6f7c1bfa02dbf42ad19d8220dc0"
         },
         {
             "SPDXID": "SPDXRef-Package-Compact-Language-Detector-v3",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/cld3",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/cld_3/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/cld3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/cld3",
             "licenseConcluded": "Apache-2.0",
-            "name": "Compact Language Detector v3"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Compact Language Detector v3",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-compiler-rt",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://compiler-rt.llvm.org/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/compiler-rt/src/LICENSE.TXT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:llvm:compiler-rt",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-compiler-rt-src-license.txt"
-            ],
-            "name": "compiler-rt"
+            "filesAnalyzed": false,
+            "homepage": "https://compiler-rt.llvm.org/",
+            "licenseConcluded": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "licenseDeclared": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "name": "compiler-rt",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Google-Chrome-Content-Analysis-Connector-Agent-SDK",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/chromium/content_analysis_sdk",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/content_analysis_sdk/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/chromium/content_analysis_sdk",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/chromium/content_analysis_sdk",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Google Chrome Content Analysis Connector Agent SDK"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Google Chrome Content Analysis Connector Agent SDK",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Core-ML-Tools",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/apple/coremltools",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/coremltools/mlmodel/format/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/apple/coremltools@8.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/apple/coremltools",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Core ML Tools"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Core ML Tools",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 1a0d051c945cfa06d2ef6c9745538ac803f6b2bb",
+            "versionInfo": "8.2"
         },
         {
             "SPDXID": "SPDXRef-Package-cpuinfo",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/pytorch/cpuinfo",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/cpuinfo/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/pytorch/cpuinfo@735b2ac12f69aaf408784ed251b9bd6319cfc62d",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/pytorch/cpuinfo",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "cpuinfo"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "cpuinfo",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "735b2ac12f69aaf408784ed251b9bd6319cfc62d"
         },
         {
             "SPDXID": "SPDXRef-Package-CrabbyAvif---Library-for-decoding-AVIF-files.",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/webmproject/CrabbyAvif",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/crabbyavif/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/webmproject/crabbyavif@7466a44ac80893803d4a7168b98dc6cd02d1fe2d",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/webmproject/CrabbyAvif",
             "licenseConcluded": "Apache-2.0",
-            "name": "CrabbyAvif - Library for decoding AVIF files."
+            "licenseDeclared": "Apache-2.0",
+            "name": "CrabbyAvif - Library for decoding AVIF files.",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "7466a44ac80893803d4a7168b98dc6cd02d1fe2d"
         },
         {
             "SPDXID": "SPDXRef-Package-Crashpad",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/crashpad/crashpad",
             "externalRefs": [
                 {
@@ -732,12 +945,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/crashpad/crashpad",
             "licenseConcluded": "Apache-2.0",
-            "name": "Crashpad"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Crashpad",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "631b657792edbfbbef411956f503311fa395e9a1"
         },
         {
             "SPDXID": "SPDXRef-Package-getopt",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://sourceware.org/ml/newlib/2005/msg00758.html",
             "externalRefs": [
                 {
@@ -746,14 +964,16 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-crashpad-crashpad-third-party-getopt-license"
-            ],
-            "name": "getopt"
+            "filesAnalyzed": false,
+            "homepage": "https://sourceware.org/ml/newlib/2005/msg00758.html",
+            "licenseConcluded": "LicenseRef-third-party-crashpad-crashpad-third-party-getopt-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "getopt",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Linux-Syscall-Support",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/linux-syscall-support/",
             "externalRefs": [
                 {
@@ -762,56 +982,107 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-lss-license"
-            ],
-            "name": "Linux Syscall Support"
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/linux-syscall-support/",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Linux Syscall Support",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-CRC32C",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/crc32c",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/crc32c/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/crc32c@1.0.7.git-5998f8451548244de8cde7fab387a550e7c4497d",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/crc32c",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "CRC32C"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "CRC32C",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 5998f8451548244de8cde7fab387a550e7c4497d",
+            "versionInfo": "1.0.7.git-5998f8451548244de8cde7fab387a550e7c4497d"
         },
         {
             "SPDXID": "SPDXRef-Package-d3",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/d3/d3",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/d3/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/d3/d3@7.8.4",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:d3.js_project:d3.js:7.8.4::~~~node.js~~",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/d3/d3",
             "licenseConcluded": "ISC",
-            "name": "d3"
+            "licenseDeclared": "ISC",
+            "name": "d3",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 37b1960e0af52d12bc7bbea2ed932ea954c36d14",
+            "versionInfo": "7.8.4"
         },
         {
             "SPDXID": "SPDXRef-Package-dav1d-is-an-AV1-decoder---",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://code.videolan.org/videolan/dav1d",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/dav1d/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:videolan:dav1d",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://code.videolan.org/videolan/dav1d",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "dav1d is an AV1 decoder :)"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "dav1d is an AV1 decoder :)",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "master"
         },
         {
             "SPDXID": "SPDXRef-Package-Dawn",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://dawn.googlesource.com/dawn",
             "externalRefs": [
                 {
@@ -820,44 +1091,69 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://dawn.googlesource.com/dawn",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Dawn"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Dawn",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "a117f96e09e88e76c0a9e3b553b7316cda50633d"
         },
         {
             "SPDXID": "SPDXRef-Package-EGL-Registry",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/EGL-Registry/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/dawn/third_party/EGL-Registry/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/egl-registry",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-dawn-third-party-egl-registry-license"
-            ],
-            "name": "EGL-Registry"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/EGL-Registry/",
+            "licenseConcluded": "Apache-2.0 AND MIT",
+            "licenseDeclared": "Apache-2.0 AND MIT",
+            "name": "EGL-Registry",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-DirectX-Shader-Compiler",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/microsoft/DirectXShaderCompiler",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/dawn/third_party/dxc/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/microsoft/directxshadercompiler",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-dawn-third-party-dxc-license.txt"
-            ],
-            "name": "DirectX Shader Compiler"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
+            "licenseConcluded": "LicenseRef-third-party-dawn-third-party-dxc-license.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "DirectX Shader Compiler",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Blackmagic-DeckLink-SDK---Mac",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://software.blackmagicdesign.com/DeckLink/v10.7/Blackmagic_DeckLink_SDK_10.7.zip",
             "externalRefs": [
                 {
@@ -866,12 +1162,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://software.blackmagicdesign.com/DeckLink/v10.7/Blackmagic_DeckLink_SDK_10.7.zip",
             "licenseConcluded": "BSL-1.0",
-            "name": "Blackmagic DeckLink SDK - Mac"
+            "licenseDeclared": "BSL-1.0",
+            "name": "Blackmagic DeckLink SDK - Mac",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "10.7.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Devtools-Frontend",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/devtools/devtools-frontend",
             "externalRefs": [
                 {
@@ -880,338 +1184,662 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/devtools/devtools-frontend",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Devtools-Frontend"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Devtools-Frontend",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Acorn--a-tiny--fast-JavaScript-parser-written-in-JavaScript.",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/acornjs/acorn",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/acorn/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/acornjs/acorn@8.10.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/acornjs/acorn",
             "licenseConcluded": "MIT",
-            "name": "Acorn, a tiny, fast JavaScript parser written in JavaScript."
+            "licenseDeclared": "MIT",
+            "name": "Acorn, a tiny, fast JavaScript parser written in JavaScript.",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 8da1fdd1918c9a9a5748501017262ce18bb2f2cc",
+            "versionInfo": "8.10.0"
         },
         {
             "SPDXID": "SPDXRef-Package-CodeMirror-5",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/codemirror/CodeMirror/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/codemirror/codemirror@5.61.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/codemirror/CodeMirror/",
             "licenseConcluded": "MIT",
-            "name": "CodeMirror 5"
+            "licenseDeclared": "MIT",
+            "name": "CodeMirror 5",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: eac70bb1a31a08201e5705c788cd72e6283958f0",
+            "versionInfo": "5.61.0"
         },
         {
             "SPDXID": "SPDXRef-Package-CodeMirror-6",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/codemirror/CodeMirror.next/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/codemirror.next/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/codemirror/codemirror.next@0.19.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/codemirror/CodeMirror.next/",
             "licenseConcluded": "MIT",
-            "name": "CodeMirror 6"
+            "licenseDeclared": "MIT",
+            "name": "CodeMirror 6",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "0.19.0"
         },
         {
             "SPDXID": "SPDXRef-Package-CSP-Evaluator-Core-Library--a-tool-that-allows-developers-to-check-if-a-Content-Security-Policy--CSP--serves-as-mitigation-against-XSS-attacks",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.npmjs.com/package/csp_evaluator",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/csp_evaluator/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:npm/csp_evaluator@1.1.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.npmjs.com/package/csp_evaluator",
             "licenseConcluded": "Apache-2.0",
-            "name": "CSP Evaluator Core Library, a tool that allows developers to check if a Content Security Policy (CSP) serves as mitigation against XSS attacks"
+            "licenseDeclared": "Apache-2.0",
+            "name": "CSP Evaluator Core Library, a tool that allows developers to check if a Content Security Policy (CSP) serves as mitigation against XSS attacks",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.1.1"
         },
         {
             "SPDXID": "SPDXRef-Package-The-Diff-Match-and-Patch-libraries-offer-robust-algorithms-to-perform-the-operations-required-for-synchronizing-plain-text.",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/diff-match-patch/tree/master/javascript",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/diff/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/diff-match-patch@5.60.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/diff-match-patch/tree/master/javascript",
             "licenseConcluded": "Apache-2.0",
-            "name": "The Diff Match and Patch libraries offer robust algorithms to perform the operations required for synchronizing plain text."
+            "licenseDeclared": "Apache-2.0",
+            "name": "The Diff Match and Patch libraries offer robust algorithms to perform the operations required for synchronizing plain text.",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 0ae308daa77aeddb089cd6b7b0a443fca026266e",
+            "versionInfo": "5.60.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Lighthouse-i18n.js",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/GoogleChrome/lighthouse",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/i18n/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlechrome/lighthouse@15dad3944c2754a9e147fef9ef99934169e2ca08",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/GoogleChrome/lighthouse",
             "licenseConcluded": "Apache-2.0",
-            "name": "Lighthouse i18n.js"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Lighthouse i18n.js",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "15dad3944c2754a9e147fef9ef99934169e2ca08"
         },
         {
             "SPDXID": "SPDXRef-Package-intl-messageformat",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/formatjs/formatjs",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/intl-messageformat/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/formatjs/formatjs@9.8.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/formatjs/formatjs",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "intl-messageformat"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "intl-messageformat",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 51a665ca0a7c6129c0c93b6b7837603a8e31caa4",
+            "versionInfo": "9.8.0"
         },
         {
             "SPDXID": "SPDXRef-Package-json5",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/json5/json5",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/json5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/json5/json5@2.2.3",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:2.3:a:json5:json5:2.2.3:*:*:*:*:*:*:*",
+                    "referenceType": "cpe23Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/json5/json5",
             "licenseConcluded": "MIT",
-            "name": "json5"
+            "licenseDeclared": "MIT",
+            "name": "json5",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: de344f0",
+            "versionInfo": "2.2.3"
         },
         {
             "SPDXID": "SPDXRef-Package-legacy-javascript",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/GoogleChrome/lighthouse/tree/main/core/lib/legacy-javascript",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/legacy-javascript/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlechrome/lighthouse@0.0.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/GoogleChrome/lighthouse/tree/main/core/lib/legacy-javascript",
             "licenseConcluded": "Apache-2.0",
-            "name": "legacy-javascript"
+            "licenseDeclared": "Apache-2.0",
+            "name": "legacy-javascript",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 410adb1220ca0d36c317f64cdbc652b798561413",
+            "versionInfo": "0.0.1"
         },
         {
             "SPDXID": "SPDXRef-Package-Lighthouse",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/GoogleChrome/lighthouse",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lighthouse/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlechrome/lighthouse@13.0.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/GoogleChrome/lighthouse",
             "licenseConcluded": "Apache-2.0",
-            "name": "Lighthouse"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Lighthouse",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 440f8bf87117ef61dc970c3ce4cebf91d46eb181",
+            "versionInfo": "13.0.2"
         },
         {
             "SPDXID": "SPDXRef-Package-Lit",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/lit/lit",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/lit/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/lit/lit@2.4.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/lit/lit",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Lit"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Lit",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 02c28397c612845ffab9e22af08eecc869f8ce47",
+            "versionInfo": "2.4.1"
         },
         {
             "SPDXID": "SPDXRef-Package-Marked",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/markedjs/marked",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/marked/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/markedjs/marked@13.0.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-devtools-frontend-src-front-end-third-party-marked-license"
-            ],
-            "name": "Marked"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/markedjs/marked",
+            "licenseConcluded": "BSD-3-Clause AND MIT",
+            "licenseDeclared": "BSD-3-Clause AND MIT",
+            "name": "Marked",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: aaee616d54e82295d61a61aa26192416c2547ac4",
+            "versionInfo": "13.0.1"
         },
         {
             "SPDXID": "SPDXRef-Package-Puppeteer-Core",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/puppeteer/puppeteer/tree/main/packages/puppeteer-core",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/puppeteer/puppeteer@24.40.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/puppeteer/puppeteer/tree/main/packages/puppeteer-core",
             "licenseConcluded": "Apache-2.0",
-            "name": "Puppeteer Core"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Puppeteer Core",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 2f176220024de0238d850d64aa6b07cb1e9b8e93",
+            "versionInfo": "24.40.0"
         },
         {
             "SPDXID": "SPDXRef-Package--puppeteer-replay",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/puppeteer/replay",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer-replay/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/puppeteer/replay@3.1.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/puppeteer/replay",
             "licenseConcluded": "Apache-2.0",
-            "name": "@puppeteer/replay"
+            "licenseDeclared": "Apache-2.0",
+            "name": "@puppeteer/replay",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 8be2fd240bbe6da6fbf031164b24f5057350f175",
+            "versionInfo": "3.1.3"
         },
         {
             "SPDXID": "SPDXRef-Package-mitt",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/developit/mitt",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/mitt/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/developit/mitt@3.0.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/developit/mitt",
             "licenseConcluded": "MIT",
-            "name": "mitt"
+            "licenseDeclared": "MIT",
+            "name": "mitt",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "3.0.1"
         },
         {
             "SPDXID": "SPDXRef-Package-parsel",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/LeaVerou/parsel",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/parsel/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/leaverou/parsel@1.2.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/LeaVerou/parsel",
             "licenseConcluded": "MIT",
-            "name": "parsel"
+            "licenseDeclared": "MIT",
+            "name": "parsel",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.2.2"
         },
         {
             "SPDXID": "SPDXRef-Package-rxjs",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/ReactiveX/rxjs",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/puppeteer/third_party/rxjs/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/reactivex/rxjs@7.8.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/ReactiveX/rxjs",
             "licenseConcluded": "Apache-2.0",
-            "name": "rxjs"
+            "licenseDeclared": "Apache-2.0",
+            "name": "rxjs",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "7.8.2"
         },
         {
             "SPDXID": "SPDXRef-Package-source-map-scopes-codec",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/ChromeDevTools/source-map-scopes-codec",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/source-map-scopes-codec/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/chromedevtools/source-map-scopes-codec@0.7.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/ChromeDevTools/source-map-scopes-codec",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "source-map-scopes-codec"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "source-map-scopes-codec",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 3a84349a869ea8136056e8ce1c37cb148d36165e",
+            "versionInfo": "0.7.0"
         },
         {
             "SPDXID": "SPDXRef-Package-third-party-web",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/patrickhulce/third-party-web",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/third-party-web/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/patrickhulce/third-party-web@0.26.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/patrickhulce/third-party-web",
             "licenseConcluded": "MIT",
-            "name": "third-party-web"
+            "licenseDeclared": "MIT",
+            "name": "third-party-web",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: d60863a2ea913ed26ae0446296a0cb1cc6c71291",
+            "versionInfo": "0.26.2"
         },
         {
             "SPDXID": "SPDXRef-Package--vscode-web-custom-data",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/microsoft/vscode-custom-data",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/vscode.web-custom-data/package/LICENSE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/microsoft/vscode-custom-data@0.5.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/microsoft/vscode-custom-data",
             "licenseConcluded": "MIT",
-            "name": "@vscode/web-custom-data"
+            "licenseDeclared": "MIT",
+            "name": "@vscode/web-custom-data",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 79f0e53d9ade00eb00eda53016edb637a809ec1f",
+            "versionInfo": "0.5.2"
         },
         {
             "SPDXID": "SPDXRef-Package-Wasmparser",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/wasdk/wasmparser",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/wasmparser/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/wasdk/wasmparser@5.4.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/wasdk/wasmparser",
             "licenseConcluded": "Apache-2.0",
-            "name": "Wasmparser"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Wasmparser",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e0a3281fdd678e6e3d5624b6d939bdf7c3d215ad",
+            "versionInfo": "5.4.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Web-Vitals",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/GoogleChrome/web-vitals",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/devtools-frontend/src/front_end/third_party/web-vitals/package/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlechrome/web-vitals@5.1.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/GoogleChrome/web-vitals",
             "licenseConcluded": "Apache-2.0",
-            "name": "Web Vitals"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Web Vitals",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 1b872cf5f2159e8ace0e98d55d8eb54fb09adfbe",
+            "versionInfo": "5.1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-dom-distiller-js",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/chromium/dom-distiller",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/dom_distiller_js/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/chromium/dom-distiller@36c7178512",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-dom-distiller-js-license"
-            ],
-            "name": "dom-distiller-js"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/chromium/dom-distiller",
+            "licenseConcluded": "BSD-3-Clause AND Apache-2.0",
+            "licenseDeclared": "BSD-3-Clause AND Apache-2.0",
+            "name": "dom-distiller-js",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 36c717851221b0f3a0a337a5930162b5933e872c",
+            "versionInfo": "36c7178512"
         },
         {
             "SPDXID": "SPDXRef-Package-dragonbox",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/jk-jeon/dragonbox",
             "externalRefs": [
                 {
@@ -1223,73 +1851,144 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/dragonbox/src/LICENSE-Boost",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/jk-jeon/dragonbox@beeeef91cf6fef89a4d4ba5e95d47ca64ccb3a44",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-dragonbox-src-license-apache2-llvm",
-                "LicenseRef-third-party-dragonbox-src-license-boost"
-            ],
-            "name": "dragonbox"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/jk-jeon/dragonbox",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+            "name": "dragonbox",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "beeeef91cf6fef89a4d4ba5e95d47ca64ccb3a44"
         },
         {
             "SPDXID": "SPDXRef-Package-Emoji-Segmenter",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/googlei18n/emoji-segmenter",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/emoji-segmenter/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlei18n/emoji-segmenter@0.3.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/googlei18n/emoji-segmenter",
             "licenseConcluded": "Apache-2.0",
-            "name": "Emoji Segmenter"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Emoji Segmenter",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 955936be8b391e00835257059607d7c5b72ce744",
+            "versionInfo": "0.3.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Expat-XML-Parser",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/libexpat/libexpat",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/expat/src/expat/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/libexpat/libexpat@R_2_7_5-0-gf31adfd5",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:libexpat_project:libexpat:2.7.5",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/libexpat/libexpat",
             "licenseConcluded": "MIT",
-            "name": "Expat XML Parser"
+            "licenseDeclared": "MIT",
+            "name": "Expat XML Parser",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
+            "versionInfo": "R_2_7_5-0-gf31adfd5"
         },
         {
             "SPDXID": "SPDXRef-Package-FarmHash",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/farmhash",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/farmhash/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/farmhash@1.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/farmhash",
             "licenseConcluded": "MIT",
-            "name": "FarmHash"
+            "licenseDeclared": "MIT",
+            "name": "FarmHash",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 816a4ae622e964763ca0862d9dbd19324a1eaf45",
+            "versionInfo": "1.1"
         },
         {
             "SPDXID": "SPDXRef-Package-fast-float",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/fastfloat/fast_float",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/fast_float/src/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/fastfloat/fast_float@7.0.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/fastfloat/fast_float",
             "licenseConcluded": "MIT",
-            "name": "fast_float"
+            "licenseDeclared": "MIT",
+            "name": "fast_float",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
+            "versionInfo": "7.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-V8-fork-of-fdlibm",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://source.chromium.org/chromium/chromium/src/+/master:v8/src/base/ieee754.cc",
             "externalRefs": [
                 {
@@ -1298,26 +1997,47 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://source.chromium.org/chromium/chromium/src/+/master:v8/src/base/ieee754.cc",
             "licenseConcluded": "SunPro",
-            "name": "V8 fork of fdlibm"
+            "licenseDeclared": "SunPro",
+            "name": "V8 fork of fdlibm",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "c512d6173f33c6b8301d3fba9384edc9fc1f9e45"
         },
         {
             "SPDXID": "SPDXRef-Package-federated-compute",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google-parfait/federated-compute/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/federated_compute/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google-parfait/federated-compute@1942343ebb949c8b12e57b52546e9b5ad10e7a50",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google-parfait/federated-compute/",
             "licenseConcluded": "Apache-2.0",
-            "name": "federated-compute"
+            "licenseDeclared": "Apache-2.0",
+            "name": "federated-compute",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1942343ebb949c8b12e57b52546e9b5ad10e7a50"
         },
         {
             "SPDXID": "SPDXRef-Package-ffmpeg",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://git.ffmpeg.org/ffmpeg.git",
             "externalRefs": [
                 {
@@ -1326,12 +2046,19 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://git.ffmpeg.org/ffmpeg.git",
             "licenseConcluded": "LGPL-2.1-only",
-            "name": "ffmpeg"
+            "licenseDeclared": "LGPL-2.1-only",
+            "name": "ffmpeg",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-2-dim-General-Purpose-FFT--Fast-Fourier-Cosine-Sine-Transform--Package",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
             "externalRefs": [
                 {
@@ -1340,214 +2067,412 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-fft2d-license"
-            ],
-            "name": "2-dim General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package"
+            "filesAnalyzed": false,
+            "homepage": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
+            "licenseConcluded": "LicenseRef-third-party-fft2d-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "2-dim General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "2006/12/28"
         },
         {
             "SPDXID": "SPDXRef-Package-flac",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/xiph/flac.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/flac/COPYING.Xiph",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/xiph/flac@1.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/xiph/flac.git",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "flac"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "flac",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: b32e5cbf9818ca23dd22aaa75522042c16ea7d17",
+            "versionInfo": "1.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-FlatBuffers",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/flatbuffers",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/flatbuffers/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/flatbuffers@a86afae9399bbe631d1ea0783f8816e780e236cc",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:flatbuffers",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/flatbuffers",
             "licenseConcluded": "Apache-2.0",
-            "name": "FlatBuffers"
+            "licenseDeclared": "Apache-2.0",
+            "name": "FlatBuffers",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "a86afae9399bbe631d1ea0783f8816e780e236cc"
         },
         {
             "SPDXID": "SPDXRef-Package-fontconfig",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.freedesktop.org/wiki/Software/fontconfig/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/fontconfig/src/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:fontconfig_project:fontconfig:2.17.1",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-fontconfig-src-copying"
-            ],
-            "name": "fontconfig"
+            "filesAnalyzed": false,
+            "homepage": "http://www.freedesktop.org/wiki/Software/fontconfig/",
+            "licenseConcluded": "LicenseRef-third-party-fontconfig-src-copying",
+            "licenseDeclared": "NOASSERTION",
+            "name": "fontconfig",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "d62c2ab268d1679335daa8fb0ea6970f35224a76"
         },
         {
             "SPDXID": "SPDXRef-Package-FP16",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/Maratyszcza/FP16",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/fp16/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/maratyszcza/fp16@3d2de1816307bac63c16a297e8c4dc501b4076df",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/Maratyszcza/FP16",
             "licenseConcluded": "MIT",
-            "name": "FP16"
+            "licenseDeclared": "MIT",
+            "name": "FP16",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "3d2de1816307bac63c16a297e8c4dc501b4076df"
         },
         {
             "SPDXID": "SPDXRef-Package-FreeType",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.freetype.org/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/freetype/src/docs/FTL.TXT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:freetype:freetype:2.14.2",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://www.freetype.org/",
             "licenseConcluded": "FTL",
-            "name": "FreeType"
+            "licenseDeclared": "FTL",
+            "name": "FreeType",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 99b479dc34728936b006679a31e12b8cf432fc55",
+            "versionInfo": "VER-2-14-2-19-g99b479dc3"
         },
         {
             "SPDXID": "SPDXRef-Package-FXDiv",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/Maratyszcza/FXdiv",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/fxdiv/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/maratyszcza/fxdiv@63058eff77e11aa15bf531df5dd34395ec3017c8",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/Maratyszcza/FXdiv",
             "licenseConcluded": "MIT",
-            "name": "FXDiv"
+            "licenseDeclared": "MIT",
+            "name": "FXDiv",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "63058eff77e11aa15bf531df5dd34395ec3017c8"
         },
         {
             "SPDXID": "SPDXRef-Package-gemmlowp",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/gemmlowp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/gemmlowp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/gemmlowp@16e8662c34917be0065110bfcd9cc27d30f52fdf",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/gemmlowp",
             "licenseConcluded": "Apache-2.0",
-            "name": "gemmlowp"
+            "licenseDeclared": "Apache-2.0",
+            "name": "gemmlowp",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "16e8662c34917be0065110bfcd9cc27d30f52fdf"
         },
         {
             "SPDXID": "SPDXRef-Package-harfbuzz",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://harfbuzz.org",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/harfbuzz/src/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:harfbuzz_project:harfbuzz:13.2.1",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://harfbuzz.org",
             "licenseConcluded": "MIT-Modern-Variant",
-            "name": "harfbuzz"
+            "licenseDeclared": "MIT-Modern-Variant",
+            "name": "harfbuzz",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 4fc96139259ebc35f40118e0382ac8037d928e5c",
+            "versionInfo": "13.2.1-28"
         },
         {
             "SPDXID": "SPDXRef-Package-Highway--C---library-for-SIMD",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/highway",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/highway/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/highway@84379d1c73de9681b54fbe1c035a23c7bd5d272d",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/highway",
             "licenseConcluded": "Apache-2.0",
-            "name": "Highway: C++ library for SIMD"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Highway: C++ library for SIMD",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "84379d1c73de9681b54fbe1c035a23c7bd5d272d"
         },
         {
             "SPDXID": "SPDXRef-Package-hunspell",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://hunspell.sourceforge.net/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/hunspell/COPYING.MPL",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:hunspell_project:hunspell:1.7.2",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://hunspell.sourceforge.net/",
             "licenseConcluded": "MPL-1.1",
-            "name": "hunspell"
+            "licenseDeclared": "MPL-1.1",
+            "name": "hunspell",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "96466a6"
         },
         {
             "SPDXID": "SPDXRef-Package-IAccessible2-COM-interfaces-for-accessibility",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/LinuxA11y/IAccessible2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/iaccessible2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/linuxa11y/iaccessible2@1.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-iaccessible2-license"
-            ],
-            "name": "IAccessible2 COM interfaces for accessibility"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/LinuxA11y/IAccessible2",
+            "licenseConcluded": "BSD-3-Clause AND BSD-2-Clause",
+            "licenseDeclared": "BSD-3-Clause AND BSD-2-Clause",
+            "name": "IAccessible2 COM interfaces for accessibility",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 2b8c2c79417bad4b464761a142fab45ffde8bfa8",
+            "versionInfo": "1.3"
         },
         {
             "SPDXID": "SPDXRef-Package-icu",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/unicode-org/icu",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/icu/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/unicode-org/icu@78-2",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:icu-project:international_components_for_unicode:78.2",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/unicode-org/icu",
             "licenseConcluded": "MIT",
-            "name": "icu"
+            "licenseDeclared": "MIT",
+            "name": "icu",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "78-2"
         },
         {
             "SPDXID": "SPDXRef-Package-Ink",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/ink.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/ink/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/ink@9d5367423281a8fcf5bc1c418e20477a992b270a",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/ink.git",
             "licenseConcluded": "Apache-2.0",
-            "name": "Ink"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Ink",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "9d5367423281a8fcf5bc1c418e20477a992b270a"
         },
         {
             "SPDXID": "SPDXRef-Package-Ink-Stroke-Modeler",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/ink-stroke-modeler",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/ink_stroke_modeler/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/ink-stroke-modeler@da42d439389c90ec7574f0381ec53e7f5be0c2eb",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/ink-stroke-modeler",
             "licenseConcluded": "Apache-2.0",
-            "name": "Ink Stroke Modeler"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Ink Stroke Modeler",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "da42d439389c90ec7574f0381ec53e7f5be0c2eb"
         },
         {
             "SPDXID": "SPDXRef-Package-inspector-protocol",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/deps/inspector_protocol/",
             "externalRefs": [
                 {
@@ -1556,12 +2481,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/deps/inspector_protocol/",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "inspector protocol"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "inspector protocol",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1b1bcbbe060e8c8cd8704f00f78978c50991b307"
         },
         {
             "SPDXID": "SPDXRef-Package-ipcz",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/chromium/src/third_party/ipcz",
             "externalRefs": [
                 {
@@ -1570,45 +2500,79 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-ipcz-license"
-            ],
-            "name": "ipcz"
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/chromium/src/third_party/ipcz",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "ipcz",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-ISimpleDOM-COM-interfaces-for-accessibility",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/mozilla/gecko-dev",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/isimpledom/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/mozilla/gecko-dev@3f397dafbaa9dbc7d740e440c7a5112e094588eb",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/mozilla/gecko-dev",
             "licenseConcluded": "MPL-1.1",
-            "name": "ISimpleDOM COM interfaces for accessibility"
+            "licenseDeclared": "MPL-1.1",
+            "name": "ISimpleDOM COM interfaces for accessibility",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "3f397dafbaa9dbc7d740e440c7a5112e094588eb"
         },
         {
             "SPDXID": "SPDXRef-Package-jsoncpp",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/open-source-parsers/jsoncpp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/jsoncpp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/open-source-parsers/jsoncpp@1.9.4",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:jsoncpp_project:jsoncpp:1.9.4",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-jsoncpp-license"
-            ],
-            "name": "jsoncpp"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/open-source-parsers/jsoncpp",
+            "licenseConcluded": "LicenseRef-third-party-jsoncpp-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "jsoncpp",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.9.4"
         },
         {
             "SPDXID": "SPDXRef-Package-Lens-Protos",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -1616,40 +2580,75 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Lens Protos"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Lens Protos",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "871420227"
         },
         {
             "SPDXID": "SPDXRef-Package-LevelDB--A-Fast-Persistent-Key-Value-Store",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/leveldb.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/leveldatabase/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/leveldb@1.23",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/leveldb.git",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "LevelDB: A Fast Persistent Key-Value Store"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "LevelDB: A Fast Persistent Key-Value Store",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7ee830d02b623e8ffe0b95d59a74db1e58da04c5",
+            "versionInfo": "1.23"
         },
         {
             "SPDXID": "SPDXRef-Package-libaddressinput",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/libaddressinput",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libaddressinput/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/libaddressinput@e20690c8d5178bb282641d5eb06ef0298ff4cbc5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/libaddressinput",
             "licenseConcluded": "Apache-2.0",
-            "name": "libaddressinput"
+            "licenseDeclared": "Apache-2.0",
+            "name": "libaddressinput",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "e20690c8d5178bb282641d5eb06ef0298ff4cbc5"
         },
         {
             "SPDXID": "SPDXRef-Package-Alliance-for-Open-Media-Video-Codec",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://aomedia.googlesource.com/aom/",
             "externalRefs": [
                 {
@@ -1661,47 +2660,73 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libaom/source/libaom/PATENTS",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:aomedia:aomedia:3.13.3",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libaom-source-libaom-license",
-                "LicenseRef-third-party-libaom-source-libaom-patents"
-            ],
-            "name": "Alliance for Open Media Video Codec"
+            "filesAnalyzed": false,
+            "homepage": "https://aomedia.googlesource.com/aom/",
+            "licenseConcluded": "LicenseRef-third-party-libaom-source-libaom-license AND LicenseRef-third-party-libaom-source-libaom-patents",
+            "licenseDeclared": "NOASSERTION",
+            "name": "Alliance for Open Media Video Codec",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "b63f30b6d30028a3d7d9c5223def8f3ad97dcc4c"
         },
         {
             "SPDXID": "SPDXRef-Package-FAST",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/edrosten/fast-C-src",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libaom/source/libaom/third_party/fastfeat/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/edrosten/fast-c-src",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libaom-source-libaom-third-party-fastfeat-license"
-            ],
-            "name": "FAST"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/edrosten/fast-C-src",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "FAST",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-vector",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/goldsborough/vector",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libaom/source/libaom/third_party/vector/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/goldsborough/vector",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/goldsborough/vector",
             "licenseConcluded": "MIT",
-            "name": "vector"
+            "licenseDeclared": "MIT",
+            "name": "vector",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-libcxx",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://libcxx.llvm.org/",
             "externalRefs": [
                 {
@@ -1710,14 +2735,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libc---src-license.txt"
-            ],
-            "name": "libcxx"
+            "filesAnalyzed": false,
+            "homepage": "http://libcxx.llvm.org/",
+            "licenseConcluded": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "licenseDeclared": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "name": "libcxx",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-libcxxabi",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://libcxxabi.llvm.org/",
             "externalRefs": [
                 {
@@ -1726,14 +2757,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libc--abi-src-license.txt"
-            ],
-            "name": "libcxxabi"
+            "filesAnalyzed": false,
+            "homepage": "http://libcxxabi.llvm.org/",
+            "licenseConcluded": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "licenseDeclared": "NCSA AND Apache-2.0 WITH LLVM-exception AND MIT",
+            "name": "libcxxabi",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-libgav1",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/codecs/libgav1/",
             "externalRefs": [
                 {
@@ -1742,42 +2779,75 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/codecs/libgav1/",
             "licenseConcluded": "Apache-2.0",
-            "name": "libgav1"
+            "licenseDeclared": "Apache-2.0",
+            "name": "libgav1",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "40f58ed32ff39071c3f2a51056dbc49a070af0dc"
         },
         {
             "SPDXID": "SPDXRef-Package-libjpeg-turbo",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/libjpeg-turbo/libjpeg-turbo/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libjpeg_turbo/LICENSE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/libjpeg-turbo/libjpeg-turbo@3.1.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libjpeg-turbo-license.md"
-            ],
-            "name": "libjpeg-turbo"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo/",
+            "licenseConcluded": "IJG AND BSD-3-Clause AND Zlib",
+            "licenseDeclared": "IJG AND BSD-3-Clause AND Zlib",
+            "name": "libjpeg-turbo",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 20ade4dea9589515a69793e447a6c6220b464535",
+            "versionInfo": "3.1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-International-Phone-Number-Library",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/googlei18n/libphonenumber/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libphonenumber/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/googlei18n/libphonenumber@140dfeb81b753388e8a672900fb7a971e9a0d362",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/googlei18n/libphonenumber/",
             "licenseConcluded": "Apache-2.0",
-            "name": "International Phone Number Library"
+            "licenseDeclared": "Apache-2.0",
+            "name": "International Phone Number Library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "140dfeb81b753388e8a672900fb7a971e9a0d362"
         },
         {
             "SPDXID": "SPDXRef-Package-libsecret",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://git.gnome.org/browse/libsecret/",
             "externalRefs": [
                 {
@@ -1786,26 +2856,48 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://git.gnome.org/browse/libsecret/",
             "licenseConcluded": "LGPL-2.1-only",
-            "name": "libsecret"
+            "licenseDeclared": "LGPL-2.1-only",
+            "name": "libsecret",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e8a2b3cd5addd9605de513b8ee0d437c1e82c16c",
+            "versionInfo": "0.18"
         },
         {
             "SPDXID": "SPDXRef-Package-libsrtp",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/cisco/libsrtp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libsrtp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/cisco/libsrtp@fd08747fa6800b321d53e15feb34da12dc697dee",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/cisco/libsrtp",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "libsrtp"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "libsrtp",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "fd08747fa6800b321d53e15feb34da12dc697dee"
         },
         {
             "SPDXID": "SPDXRef-Package-Android-Explicit-Synchronization",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://source.android.com",
             "externalRefs": [
                 {
@@ -1814,27 +2906,49 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://source.android.com",
             "licenseConcluded": "Apache-2.0",
-            "name": "Android Explicit Synchronization"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Android Explicit Synchronization",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "d29ac04dc81e6b072c091c5b1342a282765ea250"
         },
         {
             "SPDXID": "SPDXRef-Package-Libtess2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/memononen/libtess2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libtess2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/memononen/libtess2@1.0.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/memononen/libtess2",
             "licenseConcluded": "SGI-B-2.0",
-            "name": "Libtess2"
+            "licenseDeclared": "SGI-B-2.0",
+            "name": "Libtess2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 8dbd6483e920311a58c9af10a10beb278efebc36",
+            "versionInfo": "1.0.3"
         },
         {
             "SPDXID": "SPDXRef-Package-URL-Pattern-Library",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -1842,26 +2956,52 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "MIT",
-            "name": "URL Pattern Library"
+            "licenseDeclared": "MIT",
+            "name": "URL Pattern Library",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-libusbx",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/libusb/libusb",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libusb/src/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/libusb/libusb@1.0.17",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:libusb:libusb:1.0.17:rc1",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/libusb/libusb",
             "licenseConcluded": "LGPL-2.1-only",
-            "name": "libusbx"
+            "licenseDeclared": "LGPL-2.1-only",
+            "name": "libusbx",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 0c3d17c9b1c96afe6889ae4595abb22072fc1c0d",
+            "versionInfo": "1.0.17"
         },
         {
             "SPDXID": "SPDXRef-Package-libvpx",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/webm/libvpx",
             "externalRefs": [
                 {
@@ -1873,17 +3013,27 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libvpx/source/libvpx/PATENTS",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:webmproject:libvpx:1.16.0",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libvpx-source-libvpx-license",
-                "LicenseRef-third-party-libvpx-source-libvpx-patents"
-            ],
-            "name": "libvpx"
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/webm/libvpx",
+            "licenseConcluded": "LicenseRef-third-party-libvpx-source-libvpx-license AND LicenseRef-third-party-libvpx-source-libvpx-patents",
+            "licenseDeclared": "NOASSERTION",
+            "name": "libvpx",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "47ac1ec7f3de7d7cb3d070844c427c8f1fa9d6fc"
         },
         {
             "SPDXID": "SPDXRef-Package-WebM-container-parser-and-writer.",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/webm/libwebm",
             "externalRefs": [
                 {
@@ -1895,17 +3045,27 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libwebm/source/PATENTS.TXT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:webmproject:libwebm:1.0.0.32",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libwebm-source-license.txt",
-                "LicenseRef-third-party-libwebm-source-patents.txt"
-            ],
-            "name": "WebM container parser and writer."
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/webm/libwebm",
+            "licenseConcluded": "LicenseRef-third-party-libwebm-source-license.txt AND LicenseRef-third-party-libwebm-source-patents.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "WebM container parser and writer.",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "f2a982d748b80586ae53b89a2e6ebbc305848b8c"
         },
         {
             "SPDXID": "SPDXRef-Package-WebP-image-encoder-decoder",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/webm/libwebp",
             "externalRefs": [
                 {
@@ -1917,17 +3077,27 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libwebp/src/PATENTS",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:webmproject:libwebp:1.6.0",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-libwebp-src-copying",
-                "LicenseRef-third-party-libwebp-src-patents"
-            ],
-            "name": "WebP image encoder/decoder"
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/webm/libwebp",
+            "licenseConcluded": "LicenseRef-third-party-libwebp-src-copying AND LicenseRef-third-party-libwebp-src-patents",
+            "licenseDeclared": "NOASSERTION",
+            "name": "WebP image encoder/decoder",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "c00d83f6642e7838a12bb03bca94237f03cc2e00"
         },
         {
             "SPDXID": "SPDXRef-Package-libxml",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://xmlsoft.org",
             "externalRefs": [
                 {
@@ -1944,28 +3114,54 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libxml/src/list.c",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:xmlsoft:libxml2:2.14.6",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://xmlsoft.org",
             "licenseConcluded": "MIT",
-            "name": "libxml"
+            "licenseDeclared": "MIT",
+            "name": "libxml",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "22f9d730898d2dfcc03a484e65e1f8fc3675225f"
         },
         {
             "SPDXID": "SPDXRef-Package-libxslt",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://xmlsoft.org/XSLT",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libxslt/src/Copyright",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:xmlsoft:libxslt:1.1.45",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://xmlsoft.org/XSLT",
             "licenseConcluded": "X11",
-            "name": "libxslt"
+            "licenseDeclared": "X11",
+            "name": "libxslt",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "35323d6a15f6e63c9919ddbc0abe64c90a0dd88a"
         },
         {
             "SPDXID": "SPDXRef-Package-libyuv",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/libyuv/libyuv/",
             "externalRefs": [
                 {
@@ -1974,26 +3170,52 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/libyuv/libyuv/",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "libyuv"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "libyuv",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1922"
         },
         {
             "SPDXID": "SPDXRef-Package-libzip",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/nih-at/libzip",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/libzip/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/nih-at/libzip@66e496489bdae81bfda8b0088172871d8fda0032",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:nih:libzip:1.7.3",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/nih-at/libzip",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "libzip"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "libzip",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "66e496489bdae81bfda8b0088172871d8fda0032"
         },
         {
             "SPDXID": "SPDXRef-Package-Lit-1",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://lit.dev",
             "externalRefs": [
                 {
@@ -2002,26 +3224,48 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://lit.dev",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Lit"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Lit",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 02b8d62003a16075ce3873ac3e40db43c0254ecf",
+            "versionInfo": "3.0.2"
         },
         {
             "SPDXID": "SPDXRef-Package-LiteRT",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google-ai-edge/LiteRT",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/litert/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google-ai-edge/litert@588075c77c6895cce6397d41d2890b1aa0a14372",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google-ai-edge/LiteRT",
             "licenseConcluded": "Apache-2.0",
-            "name": "LiteRT"
+            "licenseDeclared": "Apache-2.0",
+            "name": "LiteRT",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "588075c77c6895cce6397d41d2890b1aa0a14372"
         },
         {
             "SPDXID": "SPDXRef-Package-llvm-libc",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://libc.llvm.org/",
             "externalRefs": [
                 {
@@ -2030,57 +3274,102 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-llvm-libc-src-license.txt"
-            ],
-            "name": "llvm-libc"
+            "filesAnalyzed": false,
+            "homepage": "https://libc.llvm.org/",
+            "licenseConcluded": "MIT AND NCSA",
+            "licenseDeclared": "MIT AND NCSA",
+            "name": "llvm-libc",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Lottie-Web",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/airbnb/lottie-web",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/lottie/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/airbnb/lottie-web@v5.5.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/airbnb/lottie-web",
             "licenseConcluded": "MIT",
-            "name": "Lottie Web"
+            "licenseDeclared": "MIT",
+            "name": "Lottie Web",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: f80e20477c2dc899e886e6c48c912ed8f15d8ffa",
+            "versionInfo": "v5.5.2"
         },
         {
             "SPDXID": "SPDXRef-Package-LZMA-SDK",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.7-zip.org/sdk.html",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/lzma_sdk/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:2.3:a:7-zip:7-zip:25.01:*:*:*:*:*:*:*",
+                    "referenceType": "cpe23Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://www.7-zip.org/sdk.html",
             "licenseConcluded": "LZMA-SDK-9.22",
-            "name": "LZMA SDK"
+            "licenseDeclared": "LZMA-SDK-9.22",
+            "name": "LZMA SDK",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "25.01"
         },
         {
             "SPDXID": "SPDXRef-Package-Material-color-utilities",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/material-foundation/material-color-utilities",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/material_color_utilities/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/material-foundation/material-color-utilities@bd6537fb1c4aa2164d97f96e78a9c826e360a0ed",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/material-foundation/material-color-utilities",
             "licenseConcluded": "Apache-2.0",
-            "name": "Material color utilities"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Material color utilities",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "bd6537fb1c4aa2164d97f96e78a9c826e360a0ed"
         },
         {
             "SPDXID": "SPDXRef-Package-Metrics-Protos",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -2088,26 +3377,48 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Metrics Protos"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Metrics Protos",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "901388496"
         },
         {
             "SPDXID": "SPDXRef-Package-Headers-for-the-Windows-WebAuthn-API--webauthn.dll-",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/Microsoft/webauthn/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/microsoft_webauthn/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/microsoft/webauthn@8",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/Microsoft/webauthn/",
             "licenseConcluded": "MIT",
-            "name": "Headers for the Windows WebAuthn API (webauthn.dll)"
+            "licenseDeclared": "MIT",
+            "name": "Headers for the Windows WebAuthn API (webauthn.dll)",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c3ed95fd7603441a0253c55c14e79239cb556a9f",
+            "versionInfo": "8"
         },
         {
             "SPDXID": "SPDXRef-Package-minigbm",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/chromiumos/platform/minigbm",
             "externalRefs": [
                 {
@@ -2116,40 +3427,74 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/chromiumos/platform/minigbm",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "minigbm"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "minigbm",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-modp-base64-decoder",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/client9/stringencoders",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/modp_b64/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/client9/stringencoders@2.0.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/client9/stringencoders",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "modp base64 decoder"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "modp base64 decoder",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 26701a1c1fcb98ae43eefcaee23abc58459a6e59",
+            "versionInfo": "2.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-ARM-NEON-2-x86-SSE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/intel/ARM_NEON_2_x86_SSE",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/neon_2_sse/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/intel/arm_neon_2_x86_sse@eb8b80b28f956275e291ea04a7beb5ed8289e872",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/intel/ARM_NEON_2_x86_SSE",
             "licenseConcluded": "BSD-Source-Code",
-            "name": "ARM_NEON_2_x86_SSE"
+            "licenseDeclared": "BSD-Source-Code",
+            "name": "ARM_NEON_2_x86_SSE",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "eb8b80b28f956275e291ea04a7beb5ed8289e872"
         },
         {
-            "SPDXID": "SPDXRef-Package-Lit-1-1",
+            "SPDXID": "SPDXRef-Package-Lit-2",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://lit.dev",
             "externalRefs": [
                 {
@@ -2158,83 +3503,156 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://lit.dev",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Lit"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Lit",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "3.2.1"
         },
         {
             "SPDXID": "SPDXRef-Package-Mediapipe-Tasks-Vision",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.npmjs.com/package/@mediapipe/tasks-vision",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:npm/%40mediapipe/tasks-vision@0.10.9",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.npmjs.com/package/@mediapipe/tasks-vision",
             "licenseConcluded": "Apache-2.0",
-            "name": "Mediapipe Tasks Vision"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Mediapipe Tasks Vision",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "0.10.9"
         },
         {
             "SPDXID": "SPDXRef-Package-Microsoft-Authentication-Library-for-JavaScript--MSAL.js--for-Browser-Based-Single-Page-Applications",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.npmjs.com/package/@azure/msal-browser",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/node/node_modules/@azure/msal-browser/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:npm/%40azure/msal-browser@4.2.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.npmjs.com/package/@azure/msal-browser",
             "licenseConcluded": "MIT",
-            "name": "Microsoft Authentication Library for JavaScript (MSAL.js) for Browser-Based Single-Page Applications"
+            "licenseDeclared": "MIT",
+            "name": "Microsoft Authentication Library for JavaScript (MSAL.js) for Browser-Based Single-Page Applications",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "4.2.1"
         },
         {
             "SPDXID": "SPDXRef-Package--bufbuild-protobuf",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.npmjs.com/package/@bufbuild/protobuf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:npm/%40bufbuild/protobuf@2.2.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.npmjs.com/package/@bufbuild/protobuf",
             "licenseConcluded": "Apache-2.0",
-            "name": "@bufbuild/protobuf"
+            "licenseDeclared": "Apache-2.0",
+            "name": "@bufbuild/protobuf",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "2.2.5"
         },
         {
             "SPDXID": "SPDXRef-Package-messageformat",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.npmjs.com/package/messageformat",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/node/Apache-LICENSE-2.0.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:npm/messageformat@4.0.0-11",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.npmjs.com/package/messageformat",
             "licenseConcluded": "Apache-2.0",
-            "name": "messageformat"
+            "licenseDeclared": "Apache-2.0",
+            "name": "messageformat",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "4.0.0-11"
         },
         {
             "SPDXID": "SPDXRef-Package-oak",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/project-oak/oak/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/oak/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/project-oak/oak@96c00a6c99ac382f3f3a8f376bc7a70890d1adaa",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/project-oak/oak/",
             "licenseConcluded": "Apache-2.0",
-            "name": "oak"
+            "licenseDeclared": "Apache-2.0",
+            "name": "oak",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "96c00a6c99ac382f3f3a8f376bc7a70890d1adaa"
         },
         {
             "SPDXID": "SPDXRef-Package-Omnibox-Protos",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -2242,40 +3660,73 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Omnibox Protos"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Omnibox Protos",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "893832592"
         },
         {
             "SPDXID": "SPDXRef-Package-One-Euro-Filter",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/casiez/OneEuroFilter",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/one_euro_filter/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/casiez/oneeurofilter@492e0388079185ef25150a7109e25e2943c08d3e",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/casiez/OneEuroFilter",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "One Euro Filter"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "One Euro Filter",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "492e0388079185ef25150a7109e25e2943c08d3e"
         },
         {
             "SPDXID": "SPDXRef-Package-OpenH264",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.openh264.org/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/openh264/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:cisco:openh264:2.6.0",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://www.openh264.org/",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "OpenH264"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "OpenH264",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Open-Screen-Protocol-Library",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/openscreen",
             "externalRefs": [
                 {
@@ -2284,12 +3735,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/openscreen",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Open Screen Protocol Library"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Open Screen Protocol Library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "9499a256bc609e9efdf15a268fd047127870af41"
         },
         {
             "SPDXID": "SPDXRef-Package-BoringSSL-1",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://boringssl.googlesource.com/boringssl/",
             "externalRefs": [
                 {
@@ -2298,56 +3754,98 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-boringssl-src-license"
-            ],
-            "name": "BoringSSL"
+            "filesAnalyzed": false,
+            "homepage": "https://boringssl.googlesource.com/boringssl/",
+            "licenseConcluded": "LicenseRef-third-party-boringssl-src-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "BoringSSL",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-jsoncpp-1",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/open-source-parsers/jsoncpp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/jsoncpp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/open-source-parsers/jsoncpp",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/open-source-parsers/jsoncpp",
             "licenseConcluded": "MIT",
-            "name": "jsoncpp"
+            "licenseDeclared": "MIT",
+            "name": "jsoncpp",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-OpenXR-SDK",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/OpenXR-SDK",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/openxr/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/openxr-sdk@1.1.53",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
             "licenseConcluded": "Apache-2.0",
-            "name": "OpenXR SDK"
+            "licenseDeclared": "Apache-2.0",
+            "name": "OpenXR SDK",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 75c53b6e853dc12c7b3c771edc9c9c841b15faaa",
+            "versionInfo": "1.1.53"
         },
         {
             "SPDXID": "SPDXRef-Package-JNIPP",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/mitchdowd/jnipp",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/openxr/src/src/external/jnipp/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/mitchdowd/jnipp@v1.0.0-13-gcdd6293",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/mitchdowd/jnipp",
             "licenseConcluded": "MIT",
-            "name": "JNIPP"
+            "licenseDeclared": "MIT",
+            "name": "JNIPP",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: cdd6293fca985993129f5ef5441709fc49ee507f",
+            "versionInfo": "v1.0.0-13-gcdd6293"
         },
         {
             "SPDXID": "SPDXRef-Package-android-jni-wrappers",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://gitlab.freedesktop.org/monado/utilities/android-jni-wrappers",
             "externalRefs": [
                 {
@@ -2356,42 +3854,71 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://gitlab.freedesktop.org/monado/utilities/android-jni-wrappers",
             "licenseConcluded": "Apache-2.0",
-            "name": "android-jni-wrappers"
+            "licenseDeclared": "Apache-2.0",
+            "name": "android-jni-wrappers",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-opus",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://gitlab.xiph.org/xiph/opus",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/opus/src/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:opus-codec:opus",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-opus-src-copying"
-            ],
-            "name": "opus"
+            "filesAnalyzed": false,
+            "homepage": "https://gitlab.xiph.org/xiph/opus",
+            "licenseConcluded": "LicenseRef-third-party-opus-src-copying",
+            "licenseDeclared": "NOASSERTION",
+            "name": "opus",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 55513e81d8f606bd75d0ff773d2144e5f2a732f5",
+            "versionInfo": "55513e81"
         },
         {
             "SPDXID": "SPDXRef-Package-OTS--OpenType-Sanitizer-",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/khaledhosny/ots.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/ots/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khaledhosny/ots@46bea9879127d0ff1c6601b078e2ce98e83fcd33",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/khaledhosny/ots.git",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "OTS (OpenType Sanitizer)"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "OTS (OpenType Sanitizer)",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "46bea9879127d0ff1c6601b078e2ce98e83fcd33"
         },
         {
             "SPDXID": "SPDXRef-Package-PDFium",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://pdfium.googlesource.com/pdfium/",
             "externalRefs": [
                 {
@@ -2400,14 +3927,19 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-pdfium-license"
-            ],
-            "name": "PDFium"
+            "filesAnalyzed": false,
+            "homepage": "https://pdfium.googlesource.com/pdfium/",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "PDFium",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Anti-Grain-Geometry",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://sourceforge.net/projects/agg/",
             "externalRefs": [
                 {
@@ -2416,12 +3948,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://sourceforge.net/projects/agg/",
             "licenseConcluded": "MIT",
-            "name": "Anti-Grain Geometry"
+            "licenseDeclared": "MIT",
+            "name": "Anti-Grain Geometry",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "2.3"
         },
         {
             "SPDXID": "SPDXRef-Package-C---Big-Integer-Library",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://mattmccutchen.net/bigint/",
             "externalRefs": [
                 {
@@ -2430,103 +3967,194 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-pdfium-third-party-bigint-license"
-            ],
-            "name": "C++ Big Integer Library"
+            "filesAnalyzed": false,
+            "homepage": "http://mattmccutchen.net/bigint/",
+            "licenseConcluded": "LicenseRef-third-party-pdfium-third-party-bigint-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "C++ Big Integer Library",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-OpenJPEG",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/uclouvain/openjpeg",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/pdfium/third_party/libopenjpeg/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/uclouvain/openjpeg@2.5.4",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:uclouvain:openjpeg:2.5.4",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/uclouvain/openjpeg",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "OpenJPEG"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "OpenJPEG",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6c4a29b00211eb0430fa0e5e890f1ce5c80f409f",
+            "versionInfo": "2.5.4"
         },
         {
             "SPDXID": "SPDXRef-Package-LibTIFF",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://gitlab.com/libtiff/libtiff",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/pdfium/third_party/libtiff/LICENSE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:gitlab/libtiff/libtiff@4.7.1",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:libtiff:libtiff:4.7.1",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://gitlab.com/libtiff/libtiff",
             "licenseConcluded": "libtiff",
-            "name": "LibTIFF"
+            "licenseDeclared": "libtiff",
+            "name": "LibTIFF",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 5fe20d0e9aba49a6a350ed533459d1505203838f",
+            "versionInfo": "4.7.1"
         },
         {
             "SPDXID": "SPDXRef-Package-Perfetto",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/perfetto/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/perfetto/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/perfetto",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-perfetto-license"
-            ],
-            "name": "Perfetto"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/perfetto/",
+            "licenseConcluded": "blessing AND BSD-3-Clause AND Apache-2.0",
+            "licenseDeclared": "blessing AND BSD-3-Clause AND Apache-2.0",
+            "name": "Perfetto",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-PFFFT--a-pretty-fast-FFT.",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://bitbucket.org/jpommier/pffft/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/pffft/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:bitbucket/jpommier/pffft@483453d8f766",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-pffft-license"
-            ],
-            "name": "PFFFT: a pretty fast FFT."
+            "filesAnalyzed": false,
+            "homepage": "https://bitbucket.org/jpommier/pffft/",
+            "licenseConcluded": "LicenseRef-third-party-pffft-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "PFFFT: a pretty fast FFT.",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "483453d8f766"
         },
         {
             "SPDXID": "SPDXRef-Package-Polymer",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/Polymer/polymer.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/polymer/LICENSE.polymer",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/polymer/polymer@3.5.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/Polymer/polymer.git",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Polymer"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Polymer",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 78f75e3108f43744fc135e06c2e50ab0384c6f39",
+            "versionInfo": "3.5.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Private-Join-and-Compute-subset",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/private-join-and-compute",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/private-join-and-compute/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/private-join-and-compute@08df854f9fa14304fb4f19df48c7b6bc31f140d3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/private-join-and-compute",
             "licenseConcluded": "Apache-2.0",
-            "name": "Private Join and Compute subset"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Private Join and Compute subset",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "08df854f9fa14304fb4f19df48c7b6bc31f140d3"
         },
         {
             "SPDXID": "SPDXRef-Package-PSM--Private-Set-Membership--client-side",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -2534,68 +4162,130 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "Apache-2.0",
-            "name": "PSM (Private Set Membership) client side"
+            "licenseDeclared": "Apache-2.0",
+            "name": "PSM (Private Set Membership) client side",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Protocol-Buffers",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/protobuf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/protobuf/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/protobuf@33.0",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:protobuf:33.0",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/protobuf",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Protocol Buffers"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Protocol Buffers",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: a79f2d2e9fadd75e94f3fe40a0399bf0a5d90551",
+            "versionInfo": "33.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Protocol-Buffers--javascript-",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/protocolbuffers/protobuf-javascript",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/protobuf-javascript/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/protocolbuffers/protobuf-javascript@31.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/protocolbuffers/protobuf-javascript",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Protocol Buffers (javascript)"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Protocol Buffers (javascript)",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e6d763860001ba1a76a63adcff5efb12b1c96024",
+            "versionInfo": "31.1"
         },
         {
             "SPDXID": "SPDXRef-Package-utf8-range",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/protocolbuffers/protobuf/tree/main/third_party/utf8_range",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/protobuf/third_party/utf8_range/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/protocolbuffers/protobuf",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/protocolbuffers/protobuf/tree/main/third_party/utf8_range",
             "licenseConcluded": "MIT",
-            "name": "utf8_range"
+            "licenseDeclared": "MIT",
+            "name": "utf8_range",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-pthreadpool",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/pthreadpool",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/pthreadpool/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/pthreadpool@d90cd6f1493e09d12c407243f7f331a8cda55efb",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/pthreadpool",
             "licenseConcluded": "BSD-2-Clause",
-            "name": "pthreadpool"
+            "licenseDeclared": "BSD-2-Clause",
+            "name": "pthreadpool",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "d90cd6f1493e09d12c407243f7f331a8cda55efb"
         },
         {
             "SPDXID": "SPDXRef-Package-Puffin-deterministic-deflate-recompressor",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://android.googlesource.com/platform/external/puffin",
             "externalRefs": [
                 {
@@ -2604,1484 +4294,2959 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://android.googlesource.com/platform/external/puffin",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Puffin deterministic deflate recompressor"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Puffin deterministic deflate recompressor",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e0820dcfebfb4df925be2e37ad8f56c00dc624f5",
+            "versionInfo": "1.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-re2---an-efficient--principled-regular-expression-library",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/re2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/re2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/re2@1e44e72d31ddc66b783a545e9d9fcaa876a146b7",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/re2",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "re2 - an efficient, principled regular expression library"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "re2 - an efficient, principled regular expression library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1e44e72d31ddc66b783a545e9d9fcaa876a146b7"
         },
         {
             "SPDXID": "SPDXRef-Package-Recurrent-neural-network-for-audio-noise-reduction",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/xiph/rnnoise",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rnnoise/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/xiph/rnnoise@91ef401f4c3536c6de999ac609262691ec888c4c",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/xiph/rnnoise",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Recurrent neural network for audio noise reduction"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Recurrent neural network for audio noise reduction",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "91ef401f4c3536c6de999ac609262691ec888c4c"
         },
         {
             "SPDXID": "SPDXRef-Package-adler2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/adler2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/adler2-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/adler2@2.0.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/adler2",
             "licenseConcluded": "Apache-2.0",
-            "name": "adler2"
+            "licenseDeclared": "Apache-2.0",
+            "name": "adler2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 89a031a0f42eeff31c70dc598b398cbf31f1680f",
+            "versionInfo": "2.0.1"
         },
         {
             "SPDXID": "SPDXRef-Package-anyhow",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/anyhow",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/anyhow-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/anyhow@1.0.102",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/anyhow",
             "licenseConcluded": "Apache-2.0",
-            "name": "anyhow"
+            "licenseDeclared": "Apache-2.0",
+            "name": "anyhow",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 5c657b32522023a9f7ef883fb08582fd8e656b1a",
+            "versionInfo": "1.0.102"
         },
         {
             "SPDXID": "SPDXRef-Package-array-init",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/array-init",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/array-init-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/array-init@2.1.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/array-init",
             "licenseConcluded": "Apache-2.0",
-            "name": "array-init"
+            "licenseDeclared": "Apache-2.0",
+            "name": "array-init",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 60635047ab2800832319829840c68df03c39945b",
+            "versionInfo": "2.1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-arrayvec",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/arrayvec",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/arrayvec-v0_7/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/arrayvec@0.7.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/arrayvec",
             "licenseConcluded": "Apache-2.0",
-            "name": "arrayvec"
+            "licenseDeclared": "Apache-2.0",
+            "name": "arrayvec",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 0aede877fe0bfb1ba5e3c2024df8c0958d503a83",
+            "versionInfo": "0.7.6"
         },
         {
             "SPDXID": "SPDXRef-Package-bitflags",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/bitflags",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bitflags-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/bitflags@1.3.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/bitflags",
             "licenseConcluded": "Apache-2.0",
-            "name": "bitflags"
+            "licenseDeclared": "Apache-2.0",
+            "name": "bitflags",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ed185cfb1c447c1b4bd6ac021c9ec3bb02c9e2f2",
+            "versionInfo": "1.3.2"
         },
         {
             "SPDXID": "SPDXRef-Package-bitflags-1",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/bitflags",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bitflags-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/bitflags@2.11.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/bitflags",
             "licenseConcluded": "Apache-2.0",
-            "name": "bitflags"
+            "licenseDeclared": "Apache-2.0",
+            "name": "bitflags",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 60c6a72743c53f43b56cebc8f2f1bd70f63863f8",
+            "versionInfo": "2.11.0"
         },
         {
             "SPDXID": "SPDXRef-Package-bytemuck",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/bytemuck",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/bytemuck@1.25.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/bytemuck",
             "licenseConcluded": "Apache-2.0",
-            "name": "bytemuck"
+            "licenseDeclared": "Apache-2.0",
+            "name": "bytemuck",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 164cedda0eae131bc6cb67902599f4ec253642ca",
+            "versionInfo": "1.25.0"
         },
         {
             "SPDXID": "SPDXRef-Package-bytemuck-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/bytemuck_derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/bytemuck_derive-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/bytemuck_derive@1.10.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/bytemuck_derive",
             "licenseConcluded": "Apache-2.0",
-            "name": "bytemuck_derive"
+            "licenseDeclared": "Apache-2.0",
+            "name": "bytemuck_derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: abbebe597e02ac0828bb987c73a3f037cd8d62b5",
+            "versionInfo": "1.10.2"
         },
         {
             "SPDXID": "SPDXRef-Package-byteorder",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/byteorder",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/byteorder-v1/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/byteorder@1.5.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/byteorder",
             "licenseConcluded": "MIT",
-            "name": "byteorder"
+            "licenseDeclared": "MIT",
+            "name": "byteorder",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ec068eefa042d494475db125c4b034bd8e9e34dd",
+            "versionInfo": "1.5.0"
         },
         {
             "SPDXID": "SPDXRef-Package-byteorder-lite",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/byteorder-lite",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/byteorder-lite-v0_1/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/byteorder-lite@0.1.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/byteorder-lite",
             "licenseConcluded": "MIT",
-            "name": "byteorder-lite"
+            "licenseDeclared": "MIT",
+            "name": "byteorder-lite",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7d44da06a48fe10d7e23efd9a932d18a7a2def63",
+            "versionInfo": "0.1.0"
         },
         {
             "SPDXID": "SPDXRef-Package-calendrical-calculations",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/calendrical_calculations",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/calendrical_calculations-v0_2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/calendrical_calculations@0.2.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/calendrical_calculations",
             "licenseConcluded": "Apache-2.0",
-            "name": "calendrical_calculations"
+            "licenseDeclared": "Apache-2.0",
+            "name": "calendrical_calculations",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.2.4"
         },
         {
             "SPDXID": "SPDXRef-Package-cfg-if",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/cfg-if",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cfg-if-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/cfg-if@1.0.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/cfg-if",
             "licenseConcluded": "Apache-2.0",
-            "name": "cfg-if"
+            "licenseDeclared": "Apache-2.0",
+            "name": "cfg-if",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 3510ca6abea34cbbc702509a4e50ea9709925eda",
+            "versionInfo": "1.0.4"
         },
         {
             "SPDXID": "SPDXRef-Package-codespan-reporting",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/codespan-reporting",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/codespan-reporting-v0_13/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/codespan-reporting@0.13.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/codespan-reporting",
             "licenseConcluded": "Apache-2.0",
-            "name": "codespan-reporting"
+            "licenseDeclared": "Apache-2.0",
+            "name": "codespan-reporting",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ef354877a16c83e678051830b260a8f9a53778bd",
+            "versionInfo": "0.13.1"
         },
         {
             "SPDXID": "SPDXRef-Package-core-maths",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/core_maths",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/core_maths-v0_1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/core_maths@0.1.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/core_maths",
             "licenseConcluded": "MIT",
-            "name": "core_maths"
+            "licenseDeclared": "MIT",
+            "name": "core_maths",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: d8ea96acac3893ad9a7e16cd7526936fbfc51021",
+            "versionInfo": "0.1.1"
         },
         {
             "SPDXID": "SPDXRef-Package-crc32fast",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/crc32fast",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/crc32fast-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/crc32fast@1.5.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/crc32fast",
             "licenseConcluded": "Apache-2.0",
-            "name": "crc32fast"
+            "licenseDeclared": "Apache-2.0",
+            "name": "crc32fast",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: dbf4f76cd71cdcc57d9164cbd46890d53ce0423c",
+            "versionInfo": "1.5.0"
         },
         {
             "SPDXID": "SPDXRef-Package-cxx",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/cxx",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxx-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/cxx@1.0.194",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/cxx",
             "licenseConcluded": "Apache-2.0",
-            "name": "cxx"
+            "licenseDeclared": "Apache-2.0",
+            "name": "cxx",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 255e7afa8fbebfb5ac59d4749fd5ac981a6b68ba",
+            "versionInfo": "1.0.194"
         },
         {
             "SPDXID": "SPDXRef-Package-cxxbridge-macro",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/cxxbridge-macro",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/cxxbridge-macro-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/cxxbridge-macro@1.0.194",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/cxxbridge-macro",
             "licenseConcluded": "Apache-2.0",
-            "name": "cxxbridge-macro"
+            "licenseDeclared": "Apache-2.0",
+            "name": "cxxbridge-macro",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 255e7afa8fbebfb5ac59d4749fd5ac981a6b68ba",
+            "versionInfo": "1.0.194"
         },
         {
             "SPDXID": "SPDXRef-Package-derivre",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/derivre",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/derivre-v0_3/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/derivre@0.3.8",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/derivre",
             "licenseConcluded": "MIT",
-            "name": "derivre"
+            "licenseDeclared": "MIT",
+            "name": "derivre",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c68f60791d191a05131796771f38c2e904417074",
+            "versionInfo": "0.3.8"
         },
         {
             "SPDXID": "SPDXRef-Package-diplomat",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/diplomat",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-v0_15/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/diplomat@0.15.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/diplomat",
             "licenseConcluded": "Apache-2.0",
-            "name": "diplomat"
+            "licenseDeclared": "Apache-2.0",
+            "name": "diplomat",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6559f95efa34658b9e801b45e39f1b306c32e249",
+            "versionInfo": "0.15.0"
         },
         {
             "SPDXID": "SPDXRef-Package-diplomat-core",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/diplomat_core",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat_core-v0_15/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/diplomat_core@0.15.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/diplomat_core",
             "licenseConcluded": "Apache-2.0",
-            "name": "diplomat_core"
+            "licenseDeclared": "Apache-2.0",
+            "name": "diplomat_core",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6559f95efa34658b9e801b45e39f1b306c32e249",
+            "versionInfo": "0.15.0"
         },
         {
             "SPDXID": "SPDXRef-Package-diplomat-runtime",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/diplomat-runtime",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/diplomat-runtime-v0_15/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/diplomat-runtime@0.15.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/diplomat-runtime",
             "licenseConcluded": "Apache-2.0",
-            "name": "diplomat-runtime"
+            "licenseDeclared": "Apache-2.0",
+            "name": "diplomat-runtime",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6559f95efa34658b9e801b45e39f1b306c32e249",
+            "versionInfo": "0.15.0"
         },
         {
             "SPDXID": "SPDXRef-Package-displaydoc",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/displaydoc",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/displaydoc-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/displaydoc@0.2.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/displaydoc",
             "licenseConcluded": "Apache-2.0",
-            "name": "displaydoc"
+            "licenseDeclared": "Apache-2.0",
+            "name": "displaydoc",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e4028851bfb82998300237f7568a45f589a19e40",
+            "versionInfo": "0.2.5"
         },
         {
             "SPDXID": "SPDXRef-Package-either",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/either",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/either-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/either@1.15.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/either",
             "licenseConcluded": "Apache-2.0",
-            "name": "either"
+            "licenseDeclared": "Apache-2.0",
+            "name": "either",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 59ae1fce0cec62c886fcd486e06b7e219bc7ce48",
+            "versionInfo": "1.15.0"
         },
         {
             "SPDXID": "SPDXRef-Package-encoding-rs",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/encoding_rs",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/encoding_rs-v0_8/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/encoding_rs@0.8.35",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-rust-chromium-crates-io-vendor-encoding-rs-v0-8-license-apache"
-            ],
-            "name": "encoding_rs"
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/encoding_rs",
+            "licenseConcluded": "Apache-2.0 AND BSD-3-Clause",
+            "licenseDeclared": "Apache-2.0 AND BSD-3-Clause",
+            "name": "encoding_rs",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 2fa58aecf537cc76ff52c0eb3d5e9f8fda466844",
+            "versionInfo": "0.8.35"
         },
         {
             "SPDXID": "SPDXRef-Package-equivalent",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/equivalent",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/equivalent-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/equivalent@1.0.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/equivalent",
             "licenseConcluded": "Apache-2.0",
-            "name": "equivalent"
+            "licenseDeclared": "Apache-2.0",
+            "name": "equivalent",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 44cdd44f8b8ebb5f9ae096c7550a5e74ffb7d6ae",
+            "versionInfo": "1.0.2"
         },
         {
             "SPDXID": "SPDXRef-Package-fdeflate",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/fdeflate",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/fdeflate-v0_3/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/fdeflate@0.3.7",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/fdeflate",
             "licenseConcluded": "Apache-2.0",
-            "name": "fdeflate"
+            "licenseDeclared": "Apache-2.0",
+            "name": "fdeflate",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c365c7e6ffa81feb2e1fb762eed7299f05c9b0ca",
+            "versionInfo": "0.3.7"
         },
         {
             "SPDXID": "SPDXRef-Package-flate2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/flate2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/flate2-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/flate2@1.1.9",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/flate2",
             "licenseConcluded": "Apache-2.0",
-            "name": "flate2"
+            "licenseDeclared": "Apache-2.0",
+            "name": "flate2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 19ddb18bf11199858fbc6504d079448fafd1606e",
+            "versionInfo": "1.1.9"
         },
         {
             "SPDXID": "SPDXRef-Package-foldhash",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/foldhash",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/foldhash-v0_2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/foldhash@0.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/foldhash",
             "licenseConcluded": "Zlib",
-            "name": "foldhash"
+            "licenseDeclared": "Zlib",
+            "name": "foldhash",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 8f878c636fda9c9e93384824ea45e06d03f009f5",
+            "versionInfo": "0.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-font-types",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/font-types",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/font-types-v0_11/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/font-types@0.11.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/font-types",
             "licenseConcluded": "Apache-2.0",
-            "name": "font-types"
+            "licenseDeclared": "Apache-2.0",
+            "name": "font-types",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7eb71698e8db0bab943f0989c0da2a07ddb01b62",
+            "versionInfo": "0.11.1"
         },
         {
             "SPDXID": "SPDXRef-Package-hashbrown",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/hashbrown",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/hashbrown-v0_15/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/hashbrown@0.15.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/hashbrown",
             "licenseConcluded": "Apache-2.0",
-            "name": "hashbrown"
+            "licenseDeclared": "Apache-2.0",
+            "name": "hashbrown",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: b751eef8e99ccf3652046ef4a9e1ec47c1bfb78d",
+            "versionInfo": "0.15.5"
         },
         {
             "SPDXID": "SPDXRef-Package-hashbrown-1",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/hashbrown",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/hashbrown-v0_16/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/hashbrown@0.16.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/hashbrown",
             "licenseConcluded": "Apache-2.0",
-            "name": "hashbrown"
+            "licenseDeclared": "Apache-2.0",
+            "name": "hashbrown",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 1876e4f02708b93903d55ef598f68e82a826518f",
+            "versionInfo": "0.16.1"
         },
         {
             "SPDXID": "SPDXRef-Package-heck",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/heck",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/heck-v0_5/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/heck@0.5.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/heck",
             "licenseConcluded": "Apache-2.0",
-            "name": "heck"
+            "licenseDeclared": "Apache-2.0",
+            "name": "heck",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 070693322aee7c5c7fbee7c9964bf8d7d3a29c96",
+            "versionInfo": "0.5.0"
         },
         {
             "SPDXID": "SPDXRef-Package-hmac-sha256",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/hmac-sha256",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/hmac-sha256-v1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/hmac-sha256@1.1.14",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/hmac-sha256",
             "licenseConcluded": "ISC",
-            "name": "hmac-sha256"
+            "licenseDeclared": "ISC",
+            "name": "hmac-sha256",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 0cfbb5c5de4ddefb3a06b33fda8c9d54b21b8e2b",
+            "versionInfo": "1.1.14"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-calendar",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_calendar",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_calendar@2.2.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_calendar",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_calendar"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_calendar",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6f32890b737485e86b712777edb7001d2f31c9c8",
+            "versionInfo": "2.2.1"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-calendar-data",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_calendar_data",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_calendar_data-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_calendar_data@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_calendar_data",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_calendar_data"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_calendar_data",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-collections",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_collections",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_collections-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_collections@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_collections",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_collections"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_collections",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-locale",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_locale",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_locale@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_locale",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_locale"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_locale",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-locale-core",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_locale_core",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_core-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_locale_core@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_locale_core",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_locale_core"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_locale_core",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-locale-data",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_locale_data",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_locale_data-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_locale_data@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_locale_data",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_locale_data"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_locale_data",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-icu-provider",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/icu_provider",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/icu_provider-v2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/icu_provider@2.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/icu_provider",
             "licenseConcluded": "Unicode-3.0",
-            "name": "icu_provider"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "icu_provider",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "2.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-image",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/image",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/image-v0_25/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/image@0.25.10",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/image",
             "licenseConcluded": "Apache-2.0",
-            "name": "image"
+            "licenseDeclared": "Apache-2.0",
+            "name": "image",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 76e57184f22772dad1138e96954e57945406b15e",
+            "versionInfo": "0.25.10"
         },
         {
             "SPDXID": "SPDXRef-Package-indexmap",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/indexmap",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/indexmap-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/indexmap@2.13.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/indexmap",
             "licenseConcluded": "Apache-2.0",
-            "name": "indexmap"
+            "licenseDeclared": "Apache-2.0",
+            "name": "indexmap",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: a4aba99f09636ad727d934d367f701c965367cc3",
+            "versionInfo": "2.13.0"
         },
         {
             "SPDXID": "SPDXRef-Package-itoa",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/itoa",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/itoa-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/itoa@1.0.18",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/itoa",
             "licenseConcluded": "Apache-2.0",
-            "name": "itoa"
+            "licenseDeclared": "Apache-2.0",
+            "name": "itoa",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: af77385d0daf4d0e949e81f2588be2e44f69f086",
+            "versionInfo": "1.0.18"
         },
         {
             "SPDXID": "SPDXRef-Package-ixdtf",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/ixdtf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ixdtf-v0_6/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/ixdtf@0.6.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/ixdtf",
             "licenseConcluded": "Unicode-3.0",
-            "name": "ixdtf"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "ixdtf",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 29dfe2790b6cfdab94ca6a6b69f58ce54802dbf7",
+            "versionInfo": "0.6.4"
         },
         {
             "SPDXID": "SPDXRef-Package-jxl",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/jxl",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/jxl-v0_4/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/jxl@0.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/jxl",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "jxl"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "jxl",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7cf3a662ea0f487c3b47ad871aab3575d1a3146a",
+            "versionInfo": "0.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-jxl-macros",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/jxl_macros",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/jxl_macros-v0_4/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/jxl_macros@0.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/jxl_macros",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "jxl_macros"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "jxl_macros",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7cf3a662ea0f487c3b47ad871aab3575d1a3146a",
+            "versionInfo": "0.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-jxl-simd",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/jxl_simd",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/jxl_simd-v0_4/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/jxl_simd@0.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/jxl_simd",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "jxl_simd"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "jxl_simd",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7cf3a662ea0f487c3b47ad871aab3575d1a3146a",
+            "versionInfo": "0.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-jxl-transforms",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/jxl_transforms",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/jxl_transforms-v0_4/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/jxl_transforms@0.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/jxl_transforms",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "jxl_transforms"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "jxl_transforms",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7cf3a662ea0f487c3b47ad871aab3575d1a3146a",
+            "versionInfo": "0.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-lazy-static",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/lazy_static",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/lazy_static-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/lazy_static@1.5.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/lazy_static",
             "licenseConcluded": "Apache-2.0",
-            "name": "lazy_static"
+            "licenseDeclared": "Apache-2.0",
+            "name": "lazy_static",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: be7c1c43f264699f956b70ce8e29941bd1e61bde",
+            "versionInfo": "1.5.0"
         },
         {
             "SPDXID": "SPDXRef-Package-libc",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/libc",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libc-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/libc@0.2.183",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/libc",
             "licenseConcluded": "Apache-2.0",
-            "name": "libc"
+            "licenseDeclared": "Apache-2.0",
+            "name": "libc",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 5660e6fc058d1c6c27788e3ea2bc7d3e79d3c22d",
+            "versionInfo": "0.2.183"
         },
         {
             "SPDXID": "SPDXRef-Package-libm",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/libm",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/libm-v0_2/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/libm@0.2.16",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/libm",
             "licenseConcluded": "MIT",
-            "name": "libm"
+            "licenseDeclared": "MIT",
+            "name": "libm",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: dfd2203a4d6110820ad7bb65cafe1bf331a03a3d",
+            "versionInfo": "0.2.16"
         },
         {
             "SPDXID": "SPDXRef-Package-litemap",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/litemap",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/litemap-v0_8/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/litemap@0.8.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/litemap",
             "licenseConcluded": "Unicode-3.0",
-            "name": "litemap"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "litemap",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 29dfe2790b6cfdab94ca6a6b69f58ce54802dbf7",
+            "versionInfo": "0.8.1"
         },
         {
             "SPDXID": "SPDXRef-Package-llguidance",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/llguidance",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/llguidance-v1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/llguidance@1.7.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/llguidance",
             "licenseConcluded": "MIT",
-            "name": "llguidance"
+            "licenseDeclared": "MIT",
+            "name": "llguidance",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 1c63f44afcda85fd6a9396a31b2d7f739f94caa0",
+            "versionInfo": "1.7.0"
         },
         {
             "SPDXID": "SPDXRef-Package-log",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/log",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/log-v0_4/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/log@0.4.29",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/log",
             "licenseConcluded": "Apache-2.0",
-            "name": "log"
+            "licenseDeclared": "Apache-2.0",
+            "name": "log",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: b1e2df7bce7a1b685aa9bfd1db0a5cac1f0fc27d",
+            "versionInfo": "0.4.29"
         },
         {
             "SPDXID": "SPDXRef-Package-memchr",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/memchr",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/memchr-v2/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/memchr@2.8.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/memchr",
             "licenseConcluded": "MIT",
-            "name": "memchr"
+            "licenseDeclared": "MIT",
+            "name": "memchr",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 886ca4ca4820297191c6e9f7b023dc356f31a4d1",
+            "versionInfo": "2.8.0"
         },
         {
             "SPDXID": "SPDXRef-Package-miniz-oxide",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/miniz_oxide",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/miniz_oxide-v0_8/LICENSE-APACHE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/miniz_oxide@0.8.9",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/miniz_oxide",
             "licenseConcluded": "Apache-2.0",
-            "name": "miniz_oxide"
+            "licenseDeclared": "Apache-2.0",
+            "name": "miniz_oxide",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 44e43c7786e379b2b1a7fde4aa0e63be719e583d",
+            "versionInfo": "0.8.9"
         },
         {
             "SPDXID": "SPDXRef-Package-moxcms",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/moxcms",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/moxcms-v0_8/LICENSE-APACHE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/moxcms@0.8.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/moxcms",
             "licenseConcluded": "Apache-2.0",
-            "name": "moxcms"
+            "licenseDeclared": "Apache-2.0",
+            "name": "moxcms",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c4affa196727d17f21a7f6f148a558867decb470",
+            "versionInfo": "0.8.1"
         },
         {
             "SPDXID": "SPDXRef-Package-num-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/num-derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/num-derive-v0_4/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/num-derive@0.4.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/num-derive",
             "licenseConcluded": "Apache-2.0",
-            "name": "num-derive"
+            "licenseDeclared": "Apache-2.0",
+            "name": "num-derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7cc33515dd2ae0eb43c5795c50ce49c554e8ba02",
+            "versionInfo": "0.4.2"
         },
         {
             "SPDXID": "SPDXRef-Package-num-traits",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/num-traits",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/num-traits-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/num-traits@0.2.19",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/num-traits",
             "licenseConcluded": "Apache-2.0",
-            "name": "num-traits"
+            "licenseDeclared": "Apache-2.0",
+            "name": "num-traits",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7ec3d41d39b28190ec1d42db38021107b3951f3a",
+            "versionInfo": "0.2.19"
         },
         {
             "SPDXID": "SPDXRef-Package-png",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/png",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/png-v0_18/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/png@0.18.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/png",
             "licenseConcluded": "Apache-2.0",
-            "name": "png"
+            "licenseDeclared": "Apache-2.0",
+            "name": "png",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 2a3f980245e3ae38b82ade96533e7b450e8477bb",
+            "versionInfo": "0.18.1"
         },
         {
             "SPDXID": "SPDXRef-Package-potential-utf",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/potential_utf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/potential_utf-v0_1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/potential_utf@0.1.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/potential_utf",
             "licenseConcluded": "Unicode-3.0",
-            "name": "potential_utf"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "potential_utf",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 29dfe2790b6cfdab94ca6a6b69f58ce54802dbf7",
+            "versionInfo": "0.1.4"
         },
         {
             "SPDXID": "SPDXRef-Package-proc-macro2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/proc-macro2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/proc-macro2-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/proc-macro2@1.0.106",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/proc-macro2",
             "licenseConcluded": "Apache-2.0",
-            "name": "proc-macro2"
+            "licenseDeclared": "Apache-2.0",
+            "name": "proc-macro2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 58ab776b95a4c2865554badbb6629c50971a9118",
+            "versionInfo": "1.0.106"
         },
         {
             "SPDXID": "SPDXRef-Package-proc-macro-error2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/proc-macro-error2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/proc-macro-error2-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/proc-macro-error2@2.0.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/proc-macro-error2",
             "licenseConcluded": "Apache-2.0",
-            "name": "proc-macro-error2"
+            "licenseDeclared": "Apache-2.0",
+            "name": "proc-macro-error2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 9b129234ed8f50d3ff8da09041dcbd980b63fc8c",
+            "versionInfo": "2.0.1"
         },
         {
             "SPDXID": "SPDXRef-Package-proc-macro-error-attr2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/proc-macro-error-attr2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/proc-macro-error-attr2-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/proc-macro-error-attr2@2.0.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/proc-macro-error-attr2",
             "licenseConcluded": "Apache-2.0",
-            "name": "proc-macro-error-attr2"
+            "licenseDeclared": "Apache-2.0",
+            "name": "proc-macro-error-attr2",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 4302a1d749def2b2929b1292bf418bd58df04486",
+            "versionInfo": "2.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-pxfm",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/pxfm",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/pxfm-v0_1/LICENSE-APACHE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/pxfm@0.1.28",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/pxfm",
             "licenseConcluded": "Apache-2.0",
-            "name": "pxfm"
+            "licenseDeclared": "Apache-2.0",
+            "name": "pxfm",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 43c41db467e97a2e6be701815db4ddb49e5bdcef",
+            "versionInfo": "0.1.28"
         },
         {
             "SPDXID": "SPDXRef-Package-qr-code",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/qr_code",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/qr_code-v2/LICENSE-APACHE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/qr_code@2.0.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/qr_code",
             "licenseConcluded": "Apache-2.0",
-            "name": "qr_code"
+            "licenseDeclared": "Apache-2.0",
+            "name": "qr_code",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 341f62be3a91ecb05e6e0870e61f763308eaf2ff",
+            "versionInfo": "2.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-quote",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/quote",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/quote-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/quote@1.0.45",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/quote",
             "licenseConcluded": "Apache-2.0",
-            "name": "quote"
+            "licenseDeclared": "Apache-2.0",
+            "name": "quote",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 842ffde933fdd76cd1681a288bed136d8b95a97a",
+            "versionInfo": "1.0.45"
         },
         {
             "SPDXID": "SPDXRef-Package-read-fonts",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/read-fonts",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/read-fonts-v0_38/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/read-fonts@0.38.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/read-fonts",
             "licenseConcluded": "Apache-2.0",
-            "name": "read-fonts"
+            "licenseDeclared": "Apache-2.0",
+            "name": "read-fonts",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7eb71698e8db0bab943f0989c0da2a07ddb01b62",
+            "versionInfo": "0.38.0"
         },
         {
             "SPDXID": "SPDXRef-Package-regex-syntax",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/regex-syntax",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/regex-syntax-v0_8/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/regex-syntax@0.8.10",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/regex-syntax",
             "licenseConcluded": "Apache-2.0",
-            "name": "regex-syntax"
+            "licenseDeclared": "Apache-2.0",
+            "name": "regex-syntax",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 839d16bc65b60e2006d3599d20bfa6efc14049d8",
+            "versionInfo": "0.8.10"
         },
         {
             "SPDXID": "SPDXRef-Package-resb",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/resb",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/resb-v0_1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/resb@0.1.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/resb",
             "licenseConcluded": "Unicode-3.0",
-            "name": "resb"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "resb",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ed9cb2a8ac23f90c4042b369de43f1c998aa011c",
+            "versionInfo": "0.1.2"
         },
         {
             "SPDXID": "SPDXRef-Package-rustversion",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/rustversion",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/rustversion-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/rustversion@1.0.22",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/rustversion",
             "licenseConcluded": "Apache-2.0",
-            "name": "rustversion"
+            "licenseDeclared": "Apache-2.0",
+            "name": "rustversion",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 9e86f839b6a34a7d9398f243d88bf400b7fa1f7c",
+            "versionInfo": "1.0.22"
         },
         {
             "SPDXID": "SPDXRef-Package-ryu",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/ryu",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/ryu-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/ryu@1.0.23",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/ryu",
             "licenseConcluded": "Apache-2.0",
-            "name": "ryu"
+            "licenseDeclared": "Apache-2.0",
+            "name": "ryu",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: f0b52bb194befe6fd242154f2182fafd43a819b8",
+            "versionInfo": "1.0.23"
         },
         {
             "SPDXID": "SPDXRef-Package-serde",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/serde",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/serde@1.0.228",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/serde",
             "licenseConcluded": "Apache-2.0",
-            "name": "serde"
+            "licenseDeclared": "Apache-2.0",
+            "name": "serde",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: a866b336f14aa57a07f0d0be9f8762746e64ecb4",
+            "versionInfo": "1.0.228"
         },
         {
             "SPDXID": "SPDXRef-Package-serde-core",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/serde_core",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_core-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/serde_core@1.0.228",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/serde_core",
             "licenseConcluded": "Apache-2.0",
-            "name": "serde_core"
+            "licenseDeclared": "Apache-2.0",
+            "name": "serde_core",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: a866b336f14aa57a07f0d0be9f8762746e64ecb4",
+            "versionInfo": "1.0.228"
         },
         {
             "SPDXID": "SPDXRef-Package-serde-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/serde_derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_derive-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/serde_derive@1.0.228",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/serde_derive",
             "licenseConcluded": "Apache-2.0",
-            "name": "serde_derive"
+            "licenseDeclared": "Apache-2.0",
+            "name": "serde_derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: a866b336f14aa57a07f0d0be9f8762746e64ecb4",
+            "versionInfo": "1.0.228"
         },
         {
             "SPDXID": "SPDXRef-Package-serde-json",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/serde_json",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/serde_json@1.0.149",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/serde_json",
             "licenseConcluded": "Apache-2.0",
-            "name": "serde_json"
+            "licenseDeclared": "Apache-2.0",
+            "name": "serde_json",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 4f6dbfac79647d032b0997b5ab73022340c6dab7",
+            "versionInfo": "1.0.149"
         },
         {
             "SPDXID": "SPDXRef-Package-serde-json-lenient",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/serde_json_lenient",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/serde_json_lenient-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/serde_json_lenient@0.2.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/serde_json_lenient",
             "licenseConcluded": "Apache-2.0",
-            "name": "serde_json_lenient"
+            "licenseDeclared": "Apache-2.0",
+            "name": "serde_json_lenient",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ec5b6e7782647f8e165e3d2e619dbe4541071cf7",
+            "versionInfo": "0.2.4"
         },
         {
             "SPDXID": "SPDXRef-Package-simd-adler32",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/simd-adler32",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/simd-adler32-v0_3/LICENSE.md",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/simd-adler32@0.3.8",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/simd-adler32",
             "licenseConcluded": "MIT",
-            "name": "simd-adler32"
+            "licenseDeclared": "MIT",
+            "name": "simd-adler32",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: dc6439879ef4f6b88f5b5a53f2e789cfa7842a6c",
+            "versionInfo": "0.3.8"
         },
         {
             "SPDXID": "SPDXRef-Package-skrifa",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/skrifa",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/skrifa-v0_41/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/skrifa@0.41.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/skrifa",
             "licenseConcluded": "Apache-2.0",
-            "name": "skrifa"
+            "licenseDeclared": "Apache-2.0",
+            "name": "skrifa",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7eb71698e8db0bab943f0989c0da2a07ddb01b62",
+            "versionInfo": "0.41.0"
         },
         {
             "SPDXID": "SPDXRef-Package-smallvec",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/smallvec",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/smallvec-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/smallvec@1.15.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/smallvec",
             "licenseConcluded": "Apache-2.0",
-            "name": "smallvec"
+            "licenseDeclared": "Apache-2.0",
+            "name": "smallvec",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: d0f47a3ea99296498ee940b5d99f59b403c498a2",
+            "versionInfo": "1.15.1"
         },
         {
             "SPDXID": "SPDXRef-Package-stable-deref-trait",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/stable_deref_trait",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/stable_deref_trait-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/stable_deref_trait@1.2.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/stable_deref_trait",
             "licenseConcluded": "Apache-2.0",
-            "name": "stable_deref_trait"
+            "licenseDeclared": "Apache-2.0",
+            "name": "stable_deref_trait",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 30002b4228f7cdee309217b6bf6eee099dda0b00",
+            "versionInfo": "1.2.1"
         },
         {
             "SPDXID": "SPDXRef-Package-strck",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/strck",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strck-v1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/strck@1.0.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/strck",
             "licenseConcluded": "MIT",
-            "name": "strck"
+            "licenseDeclared": "MIT",
+            "name": "strck",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 4c3add2f9964ce1c5720d7924dbf5291818fc37e",
+            "versionInfo": "1.0.0"
         },
         {
             "SPDXID": "SPDXRef-Package-strum",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/strum",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum-v0_27/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/strum@0.27.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/strum",
             "licenseConcluded": "MIT",
-            "name": "strum"
+            "licenseDeclared": "MIT",
+            "name": "strum",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c8d6241123d68b2e56a8d546300508294338f69a",
+            "versionInfo": "0.27.2"
         },
         {
             "SPDXID": "SPDXRef-Package-strum-macros",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/strum_macros",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/strum_macros-v0_27/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/strum_macros@0.27.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/strum_macros",
             "licenseConcluded": "MIT",
-            "name": "strum_macros"
+            "licenseDeclared": "MIT",
+            "name": "strum_macros",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c8d6241123d68b2e56a8d546300508294338f69a",
+            "versionInfo": "0.27.2"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-bundle-flac",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-bundle-flac",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-bundle-flac-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-bundle-flac@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-bundle-flac",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-bundle-flac"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-bundle-flac",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-bundle-mp3",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-bundle-mp3",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-bundle-mp3-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-bundle-mp3@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-bundle-mp3",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-bundle-mp3"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-bundle-mp3",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-codec-pcm",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-codec-pcm",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-codec-pcm-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-codec-pcm@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-codec-pcm",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-codec-pcm"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-codec-pcm",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-codec-vorbis",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-codec-vorbis",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-codec-vorbis-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-codec-vorbis@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-codec-vorbis",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-codec-vorbis"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-codec-vorbis",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-core",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-core",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-core-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-core@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-core",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-core"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-core",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-metadata",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-metadata",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-metadata-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-metadata@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-metadata",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-metadata"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-metadata",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-symphonia-utils-xiph",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/symphonia-utils-xiph",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/symphonia-utils-xiph-v0_5/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/symphonia-utils-xiph@0.5.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/symphonia-utils-xiph",
             "licenseConcluded": "MPL-2.0",
-            "name": "symphonia-utils-xiph"
+            "licenseDeclared": "MPL-2.0",
+            "name": "symphonia-utils-xiph",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6d533f26150953a882a6a111ebd13f0abf7129d5",
+            "versionInfo": "0.5.5"
         },
         {
             "SPDXID": "SPDXRef-Package-syn",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/syn",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/syn-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/syn@2.0.117",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/syn",
             "licenseConcluded": "Apache-2.0",
-            "name": "syn"
+            "licenseDeclared": "Apache-2.0",
+            "name": "syn",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 7bcb37cdb3399977658c8b52d2441d37e42e48f2",
+            "versionInfo": "2.0.117"
         },
         {
             "SPDXID": "SPDXRef-Package-synstructure",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/synstructure",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/synstructure-v0_13/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/synstructure@0.13.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/synstructure",
             "licenseConcluded": "MIT",
-            "name": "synstructure"
+            "licenseDeclared": "MIT",
+            "name": "synstructure",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 91ead072fa43c55f35880bd7f75a2b0eab72a04e",
+            "versionInfo": "0.13.2"
         },
         {
             "SPDXID": "SPDXRef-Package-temporal-capi",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/temporal_capi",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_capi-v0_2/LICENSE-Apache",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/temporal_capi@0.2.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/temporal_capi",
             "licenseConcluded": "Apache-2.0",
-            "name": "temporal_capi"
+            "licenseDeclared": "Apache-2.0",
+            "name": "temporal_capi",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c003cc92325e19b26f8ee2f85e4a47d98cbcc781",
+            "versionInfo": "0.2.3"
         },
         {
             "SPDXID": "SPDXRef-Package-temporal-rs",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/temporal_rs",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/temporal_rs-v0_2/LICENSE-Apache",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/temporal_rs@0.2.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/temporal_rs",
             "licenseConcluded": "Apache-2.0",
-            "name": "temporal_rs"
+            "licenseDeclared": "Apache-2.0",
+            "name": "temporal_rs",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c003cc92325e19b26f8ee2f85e4a47d98cbcc781",
+            "versionInfo": "0.2.3"
         },
         {
             "SPDXID": "SPDXRef-Package-termcolor",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/termcolor",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/termcolor-v1/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/termcolor@1.4.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/termcolor",
             "licenseConcluded": "MIT",
-            "name": "termcolor"
+            "licenseDeclared": "MIT",
+            "name": "termcolor",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 71f0921f1eeceda85487098588a1602979d52493",
+            "versionInfo": "1.4.1"
         },
         {
             "SPDXID": "SPDXRef-Package-thiserror",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/thiserror",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/thiserror-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/thiserror@2.0.18",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/thiserror",
             "licenseConcluded": "Apache-2.0",
-            "name": "thiserror"
+            "licenseDeclared": "Apache-2.0",
+            "name": "thiserror",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: dc0f6a23a3fb6ae34ef117133ec43650450c4b32",
+            "versionInfo": "2.0.18"
         },
         {
             "SPDXID": "SPDXRef-Package-thiserror-impl",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/thiserror-impl",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/thiserror-impl-v2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/thiserror-impl@2.0.18",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/thiserror-impl",
             "licenseConcluded": "Apache-2.0",
-            "name": "thiserror-impl"
+            "licenseDeclared": "Apache-2.0",
+            "name": "thiserror-impl",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: dc0f6a23a3fb6ae34ef117133ec43650450c4b32",
+            "versionInfo": "2.0.18"
         },
         {
             "SPDXID": "SPDXRef-Package-timezone-provider",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/timezone_provider",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/timezone_provider-v0_2/LICENSE-Apache",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/timezone_provider@0.2.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/timezone_provider",
             "licenseConcluded": "Apache-2.0",
-            "name": "timezone_provider"
+            "licenseDeclared": "Apache-2.0",
+            "name": "timezone_provider",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c003cc92325e19b26f8ee2f85e4a47d98cbcc781",
+            "versionInfo": "0.2.3"
         },
         {
             "SPDXID": "SPDXRef-Package-tinystr",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/tinystr",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/tinystr-v0_8/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/tinystr@0.8.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/tinystr",
             "licenseConcluded": "Unicode-3.0",
-            "name": "tinystr"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "tinystr",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.8.3"
         },
         {
             "SPDXID": "SPDXRef-Package-toktrie",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/toktrie",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/toktrie-v1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/toktrie@1.7.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/toktrie",
             "licenseConcluded": "MIT",
-            "name": "toktrie"
+            "licenseDeclared": "MIT",
+            "name": "toktrie",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 1c63f44afcda85fd6a9396a31b2d7f739f94caa0",
+            "versionInfo": "1.7.0"
         },
         {
             "SPDXID": "SPDXRef-Package-typed-path",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/typed-path",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/typed-path-v0_12/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/typed-path@0.12.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/typed-path",
             "licenseConcluded": "Apache-2.0",
-            "name": "typed-path"
+            "licenseDeclared": "Apache-2.0",
+            "name": "typed-path",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ec65f79eb1f61b0e11e70859b041a0a304c3a9ff",
+            "versionInfo": "0.12.3"
         },
         {
             "SPDXID": "SPDXRef-Package-unicode-ident",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/unicode-ident",
             "externalRefs": [
                 {
@@ -4093,284 +7258,560 @@
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-ident-v1/LICENSE-UNICODE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/unicode-ident@1.0.24",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-rust-chromium-crates-io-vendor-unicode-ident-v1-license-apache",
-                "LicenseRef-third-party-rust-chromium-crates-io-vendor-unicode-ident-v1-license-unicode"
-            ],
-            "name": "unicode-ident"
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/unicode-ident",
+            "licenseConcluded": "Apache-2.0 AND Unicode-3.0",
+            "licenseDeclared": "Apache-2.0 AND Unicode-3.0",
+            "name": "unicode-ident",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 5b54a632702b5744a1c40ea01c127c0ac0498172",
+            "versionInfo": "1.0.24"
         },
         {
             "SPDXID": "SPDXRef-Package-unicode-width",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/unicode-width",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/unicode-width-v0_2/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/unicode-width@0.2.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/unicode-width",
             "licenseConcluded": "Apache-2.0",
-            "name": "unicode-width"
+            "licenseDeclared": "Apache-2.0",
+            "name": "unicode-width",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 9d98411769fe13c7c18cab0b3fbbab29ba8350ea",
+            "versionInfo": "0.2.2"
         },
         {
             "SPDXID": "SPDXRef-Package-utf8-iter",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/utf8_iter",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/utf8_iter-v1/LICENSE-APACHE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/utf8_iter@1.0.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/utf8_iter",
             "licenseConcluded": "Apache-2.0",
-            "name": "utf8_iter"
+            "licenseDeclared": "Apache-2.0",
+            "name": "utf8_iter",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6b604ea2365bd535fb66eb4bfe92a9e00e333090",
+            "versionInfo": "1.0.4"
         },
         {
             "SPDXID": "SPDXRef-Package-winapi-util",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/winapi-util",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/winapi-util-v0_1/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/winapi-util@0.1.11",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/winapi-util",
             "licenseConcluded": "MIT",
-            "name": "winapi-util"
+            "licenseDeclared": "MIT",
+            "name": "winapi-util",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 803874c57dc1f10ecd42f7c86d9de72f53818432",
+            "versionInfo": "0.1.11"
         },
         {
             "SPDXID": "SPDXRef-Package-windows-sys",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/windows-sys",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/windows-sys-v0_52/license-apache-2.0",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/windows-sys@0.52.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/windows-sys",
             "licenseConcluded": "Apache-2.0",
-            "name": "windows-sys"
+            "licenseDeclared": "Apache-2.0",
+            "name": "windows-sys",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 3a605cba064b26f2a198ac58085f8c8836f47c38",
+            "versionInfo": "0.52.0"
         },
         {
             "SPDXID": "SPDXRef-Package-windows-targets",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/windows-targets",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/windows-targets-v0_52/license-apache-2.0",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/windows-targets@0.52.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/windows-targets",
             "licenseConcluded": "Apache-2.0",
-            "name": "windows-targets"
+            "licenseDeclared": "Apache-2.0",
+            "name": "windows-targets",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: db06b51c2ebb743efb544d40e3064efa49f28d38",
+            "versionInfo": "0.52.6"
         },
         {
             "SPDXID": "SPDXRef-Package-windows-x86-64-msvc",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/windows_x86_64_msvc",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/windows_x86_64_msvc-v0_52/license-apache-2.0",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.52.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/windows_x86_64_msvc",
             "licenseConcluded": "Apache-2.0",
-            "name": "windows_x86_64_msvc"
+            "licenseDeclared": "Apache-2.0",
+            "name": "windows_x86_64_msvc",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: db06b51c2ebb743efb544d40e3064efa49f28d38",
+            "versionInfo": "0.52.6"
         },
         {
             "SPDXID": "SPDXRef-Package-writeable",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/writeable",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/writeable-v0_6/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/writeable@0.6.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/writeable",
             "licenseConcluded": "Unicode-3.0",
-            "name": "writeable"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "writeable",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 29dfe2790b6cfdab94ca6a6b69f58ce54802dbf7",
+            "versionInfo": "0.6.2"
         },
         {
             "SPDXID": "SPDXRef-Package-xml",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/xml",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/xml-v1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/xml@1.2.1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/xml",
             "licenseConcluded": "MIT",
-            "name": "xml"
+            "licenseDeclared": "MIT",
+            "name": "xml",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 798543db49000767ff4dae131fd2a9ea5fe7310b",
+            "versionInfo": "1.2.1"
         },
         {
             "SPDXID": "SPDXRef-Package-yoke",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/yoke",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-v0_8/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/yoke@0.8.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/yoke",
             "licenseConcluded": "Unicode-3.0",
-            "name": "yoke"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "yoke",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.8.2"
         },
         {
             "SPDXID": "SPDXRef-Package-yoke-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/yoke-derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/yoke-derive-v0_8/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/yoke-derive@0.8.2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/yoke-derive",
             "licenseConcluded": "Unicode-3.0",
-            "name": "yoke-derive"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "yoke-derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.8.2"
         },
         {
             "SPDXID": "SPDXRef-Package-zerofrom",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zerofrom",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-v0_1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zerofrom@0.1.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zerofrom",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zerofrom"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zerofrom",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: f4290a877dfcb0f87cad6de4abdd65f0cbb33c9c",
+            "versionInfo": "0.1.6"
         },
         {
             "SPDXID": "SPDXRef-Package-zerofrom-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zerofrom-derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerofrom-derive-v0_1/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zerofrom-derive@0.1.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zerofrom-derive",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zerofrom-derive"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zerofrom-derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: f4290a877dfcb0f87cad6de4abdd65f0cbb33c9c",
+            "versionInfo": "0.1.6"
         },
         {
             "SPDXID": "SPDXRef-Package-zerotrie",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zerotrie",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerotrie-v0_2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zerotrie@0.2.4",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zerotrie",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zerotrie"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zerotrie",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.2.4"
         },
         {
             "SPDXID": "SPDXRef-Package-zerovec",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zerovec",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-v0_11/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zerovec@0.11.6",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zerovec",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zerovec"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zerovec",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.11.6"
         },
         {
             "SPDXID": "SPDXRef-Package-zerovec-derive",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zerovec-derive",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zerovec-derive-v0_11/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zerovec-derive@0.11.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zerovec-derive",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zerovec-derive"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zerovec-derive",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: c9fac4e625ccb2c6a7aa35079fff9709db4385ac",
+            "versionInfo": "0.11.3"
         },
         {
             "SPDXID": "SPDXRef-Package-zip",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zip",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zip-v8/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zip@8.2.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zip",
             "licenseConcluded": "MIT",
-            "name": "zip"
+            "licenseDeclared": "MIT",
+            "name": "zip",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ff001c6f2a630580399ad8044a7925801ca16a98",
+            "versionInfo": "8.2.0"
         },
         {
             "SPDXID": "SPDXRef-Package-zmij",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zmij",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zmij-v1/LICENSE-MIT",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zmij@1.0.21",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zmij",
             "licenseConcluded": "MIT",
-            "name": "zmij"
+            "licenseDeclared": "MIT",
+            "name": "zmij",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 6531ba31ccf5d14b604ca41f6e2414a8dd779af0",
+            "versionInfo": "1.0.21"
         },
         {
             "SPDXID": "SPDXRef-Package-zoneinfo64",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://crates.io/crates/zoneinfo64",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/rust/chromium_crates_io/vendor/zoneinfo64-v0_3/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:cargo/zoneinfo64@0.3.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://crates.io/crates/zoneinfo64",
             "licenseConcluded": "Unicode-3.0",
-            "name": "zoneinfo64"
+            "licenseDeclared": "Unicode-3.0",
+            "name": "zoneinfo64",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: ed9cb2a8ac23f90c4042b369de43f1c998aa011c",
+            "versionInfo": "0.3.0"
         },
         {
             "SPDXID": "SPDXRef-Package-The-ruy-matrix-multiplication-library",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/ruy",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/ruy/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/ruy@1e6e50872655a73b5250f954d7b9da9a87292fd3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/ruy",
             "licenseConcluded": "Apache-2.0",
-            "name": "The ruy matrix multiplication library"
+            "licenseDeclared": "Apache-2.0",
+            "name": "The ruy matrix multiplication library",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1e6e50872655a73b5250f954d7b9da9a87292fd3"
         },
         {
             "SPDXID": "SPDXRef-Package-Search-Engines-resources",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -4378,57 +7819,107 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Search Engines resources"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Search Engines resources",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Sentencepiece",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/sentencepiece",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/sentencepiece/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/sentencepiece@8cbdf13794284c30877936f91c6f31e2c1d5aef7",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:sentencepiece",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-sentencepiece-license"
-            ],
-            "name": "Sentencepiece"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/sentencepiece",
+            "licenseConcluded": "BSD-3-Clause AND Apache-2.0 AND MIT",
+            "licenseDeclared": "BSD-3-Clause AND Apache-2.0 AND MIT",
+            "name": "Sentencepiece",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "8cbdf13794284c30877936f91c6f31e2c1d5aef7"
         },
         {
             "SPDXID": "SPDXRef-Package-Simple-Homomorphic-Encryption-Library-with-Lattices",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/shell-encryption",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/shell-encryption/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/shell-encryption@f94f58852e9b3edaf2766e348a69a70f596bb9dd",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/shell-encryption",
             "licenseConcluded": "Apache-2.0",
-            "name": "Simple Homomorphic Encryption Library with Lattices"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Simple Homomorphic Encryption Library with Lattices",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "f94f58852e9b3edaf2766e348a69a70f596bb9dd"
         },
         {
             "SPDXID": "SPDXRef-Package-simdutf-unicode-transcoder",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/simdutf/simdutf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/simdutf/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/simdutf/simdutf@7.7.0",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/simdutf/simdutf",
             "licenseConcluded": "MIT",
-            "name": "simdutf unicode transcoder"
+            "licenseDeclared": "MIT",
+            "name": "simdutf unicode transcoder",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: da645ece",
+            "versionInfo": "7.7.0"
         },
         {
             "SPDXID": "SPDXRef-Package-Skia",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -4436,100 +7927,183 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Skia"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Skia",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-SMHasher",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/aappleby/smhasher",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/smhasher/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/aappleby/smhasher@0ff96f7835817a27d0487325b6c16033e2992eb5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-smhasher-license"
-            ],
-            "name": "SMHasher"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/aappleby/smhasher",
+            "licenseConcluded": "MIT AND Unlicense",
+            "licenseDeclared": "MIT AND Unlicense",
+            "name": "SMHasher",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "0ff96f7835817a27d0487325b6c16033e2992eb5"
         },
         {
             "SPDXID": "SPDXRef-Package-Snappy--A-fast-compressor-decompressor",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://google.github.io/snappy/",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/snappy/src/COPYING",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:snappy:1.1.10",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-snappy-src-copying"
-            ],
-            "name": "Snappy: A fast compressor/decompressor"
+            "filesAnalyzed": false,
+            "homepage": "http://google.github.io/snappy/",
+            "licenseConcluded": "BSD-3-Clause AND CC-BY-4.0 AND MIT AND CC-BY-3.0",
+            "licenseDeclared": "BSD-3-Clause AND CC-BY-4.0 AND MIT AND CC-BY-3.0",
+            "name": "Snappy: A fast compressor/decompressor",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1.1.10.git.c9f9edf6d75bb065fa47468bf035e051a57bec7c"
         },
         {
             "SPDXID": "SPDXRef-Package-Speech-Dispatcher",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/brailcom/speechd",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/speech-dispatcher/COPYING.LGPL",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/brailcom/speechd@0.11.5",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/brailcom/speechd",
             "licenseConcluded": "LGPL-2.1-only",
-            "name": "Speech Dispatcher"
+            "licenseDeclared": "LGPL-2.1-only",
+            "name": "Speech Dispatcher",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 0680c0f92c43bd43aa2ac111c8ec478d8a4f94cc",
+            "versionInfo": "0.11.5"
         },
         {
             "SPDXID": "SPDXRef-Package-SPIR-V-Headers",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/SPIRV-Headers.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/spirv-headers/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/spirv-headers",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/SPIRV-Headers.git",
             "licenseConcluded": "Apache-2.0",
-            "name": "SPIR-V Headers"
+            "licenseDeclared": "Apache-2.0",
+            "name": "SPIR-V Headers",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-SPIR-V-Tools",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/spirv-tools/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/spirv-tools",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "licenseConcluded": "Apache-2.0",
-            "name": "SPIR-V Tools"
+            "licenseDeclared": "Apache-2.0",
+            "name": "SPIR-V Tools",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-sqlite",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/sqlite/sqlite",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/sqlite/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/sqlite/sqlite@3.51.3",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:sqlite:sqlite:3.51.3",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/sqlite/sqlite",
             "licenseConcluded": "blessing",
-            "name": "sqlite"
+            "licenseDeclared": "blessing",
+            "name": "sqlite",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 508ab21dc25702ed6690c4dd77da209a6bcd1239",
+            "versionInfo": "3.51.3"
         },
         {
             "SPDXID": "SPDXRef-Package-SwiftShader",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://swiftshader.googlesource.com/SwiftShader",
             "externalRefs": [
                 {
@@ -4538,56 +8112,85 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-swiftshader-license.txt"
-            ],
-            "name": "SwiftShader"
+            "filesAnalyzed": false,
+            "homepage": "https://swiftshader.googlesource.com/SwiftShader",
+            "licenseConcluded": "LicenseRef-third-party-swiftshader-license.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "SwiftShader",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-SPIRV-Headers",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/SPIRV-Headers",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Headers/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/spirv-headers",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/SPIRV-Headers",
             "licenseConcluded": "Apache-2.0",
-            "name": "SPIRV-Headers"
+            "licenseDeclared": "Apache-2.0",
+            "name": "SPIRV-Headers",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-SPIRV-Tools",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/SPIRV-Tools",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/swiftshader/third_party/SPIRV-Tools/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/spirv-tools",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
             "licenseConcluded": "Apache-2.0",
-            "name": "SPIRV-Tools"
+            "licenseDeclared": "Apache-2.0",
+            "name": "SPIRV-Tools",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-The-Arm-ASTC-Encoder",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/ARM-software/astc-encoder",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/swiftshader/third_party/astc-encoder/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/arm-software/astc-encoder",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/ARM-software/astc-encoder",
             "licenseConcluded": "Apache-2.0",
-            "name": "The Arm ASTC Encoder"
+            "licenseDeclared": "Apache-2.0",
+            "name": "The Arm ASTC Encoder",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-LLVM",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://llvm.org/",
             "externalRefs": [
                 {
@@ -4596,12 +8199,16 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://llvm.org/",
             "licenseConcluded": "Apache-2.0",
-            "name": "LLVM"
+            "licenseDeclared": "Apache-2.0",
+            "name": "LLVM",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-llvm-subzero",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://llvm.org",
             "externalRefs": [
                 {
@@ -4610,28 +8217,39 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-swiftshader-third-party-llvm-subzero-license.txt"
-            ],
-            "name": "llvm-subzero"
+            "filesAnalyzed": false,
+            "homepage": "https://llvm.org",
+            "licenseConcluded": "LicenseRef-third-party-swiftshader-third-party-llvm-subzero-license.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "llvm-subzero",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Marl",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/marl",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/swiftshader/third_party/marl/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/marl",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/marl",
             "licenseConcluded": "Apache-2.0",
-            "name": "Marl"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Marl",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Subzero",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.chromium.org/nativeclient/",
             "externalRefs": [
                 {
@@ -4640,174 +8258,319 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-swiftshader-third-party-subzero-license.txt"
-            ],
-            "name": "Subzero"
+            "filesAnalyzed": false,
+            "homepage": "https://www.chromium.org/nativeclient/",
+            "licenseConcluded": "LicenseRef-third-party-swiftshader-third-party-subzero-license.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "Subzero",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-TensorFlow-Text",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/tensorflow/text.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/tensorflow-text/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/tensorflow/text@32dc812e814c98873068fea87b4eecc2e2babed8",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/tensorflow/text.git",
             "licenseConcluded": "Apache-2.0",
-            "name": "TensorFlow Text"
+            "licenseDeclared": "Apache-2.0",
+            "name": "TensorFlow Text",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "32dc812e814c98873068fea87b4eecc2e2babed8"
         },
         {
             "SPDXID": "SPDXRef-Package-TensorFlow-Models",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/tensorflow/models",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/tensorflow_models/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/tensorflow/models@5bad7493ed8a56ad67bbadad80194d7206efac86",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/tensorflow/models",
             "licenseConcluded": "Apache-2.0",
-            "name": "TensorFlow Models"
+            "licenseDeclared": "Apache-2.0",
+            "name": "TensorFlow Models",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "5bad7493ed8a56ad67bbadad80194d7206efac86"
         },
         {
             "SPDXID": "SPDXRef-Package-TensorFlow-Lite",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/tensorflow/tensorflow",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/tflite/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/tensorflow/tensorflow@de8d7f65b6eb670e4dad0225d0d6f99bebaab559",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:google:tensorflow_lite",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-tflite-license"
-            ],
-            "name": "TensorFlow Lite"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/tensorflow/tensorflow",
+            "licenseConcluded": "LicenseRef-third-party-tflite-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "TensorFlow Lite",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "de8d7f65b6eb670e4dad0225d0d6f99bebaab559"
         },
         {
             "SPDXID": "SPDXRef-Package-Accelerated-Linear-Algebra",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/openxla/xla",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/tflite/src/third_party/xla/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/openxla/xla",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/openxla/xla",
             "licenseConcluded": "Apache-2.0",
-            "name": "Accelerated Linear Algebra"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Accelerated Linear Algebra",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-TensorFlow-Lite-Support",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/tensorflow/tflite-support",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/tflite_support/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/tensorflow/tflite-support@a1225b22c45137ed95d98564aac721060fe5515c",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/tensorflow/tflite-support",
             "licenseConcluded": "Apache-2.0",
-            "name": "TensorFlow Lite Support"
+            "licenseDeclared": "Apache-2.0",
+            "name": "TensorFlow Lite Support",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "a1225b22c45137ed95d98564aac721060fe5515c"
         },
         {
             "SPDXID": "SPDXRef-Package-UnRAR-source-for-decompressing-.RAR-and-other-files.",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.rarlab.com/rar/unrarsrc-7.2.5.tar.gz",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/unrar/src/license.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:rarlab:unrar",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-unrar-src-license.txt"
-            ],
-            "name": "UnRAR source for decompressing .RAR and other files."
+            "filesAnalyzed": false,
+            "homepage": "https://www.rarlab.com/rar/unrarsrc-7.2.5.tar.gz",
+            "licenseConcluded": "LicenseRef-third-party-unrar-src-license.txt",
+            "licenseDeclared": "NOASSERTION",
+            "name": "UnRAR source for decompressing .RAR and other files.",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "7.21.1"
         },
         {
             "SPDXID": "SPDXRef-Package-libutf",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/cls/libutf",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/utf/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/cls/libutf@ee5074db68f498a5c802dc9f1645f396c219938a",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-utf-license"
-            ],
-            "name": "libutf"
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/cls/libutf",
+            "licenseConcluded": "Unicode-DFS-2015 AND MIT",
+            "licenseDeclared": "Unicode-DFS-2015 AND MIT",
+            "name": "libutf",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "ee5074db68f498a5c802dc9f1645f396c219938a"
         },
         {
             "SPDXID": "SPDXRef-Package-Vulkan-API-headers",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/Vulkan-Headers",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/vulkan-headers/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/vulkan-headers",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:khronos:vulkan",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
             "licenseConcluded": "Apache-2.0",
-            "name": "Vulkan API headers"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Vulkan API headers",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-Vulkan-Loader-Components",
+            "attributionTexts": [
+                "Security Critical: no"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/KhronosGroup/Vulkan-Loader",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/vulkan-loader/src/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/khronosgroup/vulkan-loader",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/KhronosGroup/Vulkan-Loader",
             "licenseConcluded": "Apache-2.0",
-            "name": "Vulkan Loader Components"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Vulkan Loader Components",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-VulkanMemoryAllocator",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/vulkan_memory_allocator/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/gpuopen-librariesandsdks/vulkanmemoryallocator@309fa0e613c6db0231df03d0d7ac0c166dbee1d1",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator",
             "licenseConcluded": "MIT",
-            "name": "VulkanMemoryAllocator"
+            "licenseDeclared": "MIT",
+            "name": "VulkanMemoryAllocator",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "309fa0e613c6db0231df03d0d7ac0c166dbee1d1"
         },
         {
             "SPDXID": "SPDXRef-Package-WebRTC",
-            "downloadLocation": "NONE",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/webrtc/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:webrtc_project:webrtc",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "WebRTC"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "WebRTC",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-General-Purpose-FFT--Fast-Fourier-Cosine-Sine-Transform--Package",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
             "externalRefs": [
                 {
@@ -4816,14 +8579,19 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-webrtc-common-audio-third-party-ooura-license"
-            ],
-            "name": "General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package"
+            "filesAnalyzed": false,
+            "homepage": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
+            "licenseConcluded": "LicenseRef-third-party-webrtc-common-audio-third-party-ooura-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-spl-sqrt-floor",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://www.pertinentdetail.org/sqrt",
             "externalRefs": [
                 {
@@ -4832,15 +8600,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-webrtc-common-audio-third-party-spl-sqrt-floor-license"
-            ],
-            "name": "spl sqrt floor"
+            "filesAnalyzed": false,
+            "homepage": "http://www.pertinentdetail.org/sqrt",
+            "licenseConcluded": "LicenseRef-third-party-webrtc-common-audio-third-party-spl-sqrt-floor-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "spl sqrt floor",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-fft",
-            "downloadLocation": "NONE",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -4848,15 +8618,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-webrtc-modules-third-party-fft-license"
-            ],
-            "name": "fft"
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "LicenseRef-third-party-webrtc-modules-third-party-fft-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "fft",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-g711",
-            "downloadLocation": "NONE",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -4864,15 +8636,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-webrtc-modules-third-party-g711-license"
-            ],
-            "name": "g711"
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "LicenseRef-third-party-webrtc-modules-third-party-g711-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "g711",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-g722",
-            "downloadLocation": "NONE",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -4880,28 +8654,46 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-third-party-webrtc-modules-third-party-g722-license"
-            ],
-            "name": "g722"
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "LicenseRef-third-party-webrtc-modules-third-party-g722-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "g722",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-woff2",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/woff2",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/woff2/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/woff2@f83a17739086a433be544eb16258b1c4f64a35f9",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/woff2",
             "licenseConcluded": "MIT",
-            "name": "woff2"
+            "licenseDeclared": "MIT",
+            "name": "woff2",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "f83a17739086a433be544eb16258b1c4f64a35f9"
         },
         {
             "SPDXID": "SPDXRef-Package-Windows-Template-Library--WTL-",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://git.code.sf.net/p/wtl/git",
             "externalRefs": [
                 {
@@ -4910,68 +8702,141 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://git.code.sf.net/p/wtl/git",
             "licenseConcluded": "MS-PL",
-            "name": "Windows Template Library (WTL)"
+            "licenseDeclared": "MS-PL",
+            "name": "Windows Template Library (WTL)",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 57a7c4e2629cb85c6f27faa91650e047c4220e15",
+            "versionInfo": "10.0.9163"
         },
         {
             "SPDXID": "SPDXRef-Package-Wuffs--Wrangling-Untrusted-File-Formats-Safely-",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/wuffs-mirror-release-c",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/wuffs/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/wuffs-mirror-release-c@0.3.3",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/wuffs-mirror-release-c",
             "licenseConcluded": "Apache-2.0",
-            "name": "Wuffs (Wrangling Untrusted File Formats Safely)"
+            "licenseDeclared": "Apache-2.0",
+            "name": "Wuffs (Wrangling Untrusted File Formats Safely)",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: e3f919ccfe3ef542cfc983a82146070258fb57f8",
+            "versionInfo": "0.3.3"
         },
         {
             "SPDXID": "SPDXRef-Package-XNNPACK",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/google/xnnpack",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/xnnpack/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/google/xnnpack@1812bbe2928a32f26c5e48466712ba6460cf290c",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/google/xnnpack",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "XNNPACK"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "XNNPACK",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1812bbe2928a32f26c5e48466712ba6460cf290c"
         },
         {
             "SPDXID": "SPDXRef-Package-zlib",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/madler/zlib",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/zlib/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/madler/zlib@1.3.2",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:zlib:zlib:1.3.2",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/madler/zlib",
             "licenseConcluded": "Zlib",
-            "name": "zlib"
+            "licenseDeclared": "Zlib",
+            "name": "zlib",
+            "primaryPackagePurpose": "LIBRARY",
+            "sourceInfo": "Upstream revision: 09a1572aa624e5ddb6c075dc013880de70b1b9b9",
+            "versionInfo": "1.3.2"
         },
         {
             "SPDXID": "SPDXRef-Package-Zstandard",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/facebook/zstd",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/third_party/zstd/src/LICENSE",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/facebook/zstd@3ae099b48dfcfe02b1b3ba81ab85457f8a922e9f",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:facebook:zstandard:1.5.5",
+                    "referenceType": "cpe22Type"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/facebook/zstd",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "Zstandard"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "Zstandard",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "3ae099b48dfcfe02b1b3ba81ab85457f8a922e9f"
         },
         {
             "SPDXID": "SPDXRef-Package-C---port-of-zxcvbn--an-advanced-password-strength-estimation-library.",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://thelig.ht/code/zxcvbn-cpp",
             "externalRefs": [
                 {
@@ -4980,26 +8845,44 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://thelig.ht/code/zxcvbn-cpp",
             "licenseConcluded": "MIT",
-            "name": "C++ port of zxcvbn, an advanced password strength estimation library."
+            "licenseDeclared": "MIT",
+            "name": "C++ port of zxcvbn, an advanced password strength estimation library.",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "6559806fc0c1671aa2d77dfc66e1d4784a57beaa"
         },
         {
             "SPDXID": "SPDXRef-Package-url-parse",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://github.com/mozilla-firefox/firefox.git",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
                     "referenceLocator": "https://github.com/TeamDev-IP/Chromium-Licences/blob/v148.0.7778.97/chromium-licenses/url/third_party/mozilla/LICENSE.txt",
                     "referenceType": "url"
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:github/mozilla-firefox/firefox@c7df6606be1bfdf6d6cec37a4ff644a9841c3ec2",
+                    "referenceType": "purl"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/mozilla-firefox/firefox.git",
             "licenseConcluded": "MPL-2.0",
-            "name": "url_parse"
+            "licenseDeclared": "MPL-2.0",
+            "name": "url_parse",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "c7df6606be1bfdf6d6cec37a4ff644a9841c3ec2"
         },
         {
             "SPDXID": "SPDXRef-Package-V8-JavaScript-Engine",
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://v8.dev/",
             "externalRefs": [
                 {
@@ -5023,17 +8906,19 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-v8-license",
-                "LicenseRef-v8-license.fdlibm",
-                "LicenseRef-v8-license.strongtalk",
-                "LicenseRef-v8-license.v8"
-            ],
-            "name": "V8 JavaScript Engine"
+            "filesAnalyzed": false,
+            "homepage": "https://v8.dev/",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "V8 JavaScript Engine",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-glibc",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://www.gnu.org/software/libc/",
             "externalRefs": [
                 {
@@ -5042,12 +8927,20 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://www.gnu.org/software/libc/",
             "licenseConcluded": "LGPL-2.1-only",
-            "name": "glibc"
+            "licenseDeclared": "LGPL-2.1-only",
+            "name": "glibc",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "4e21c2075193e406a92c0d1cb091a7c804fda4d9"
         },
         {
             "SPDXID": "SPDXRef-Package-inspector-protocol-1",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "https://chromium.googlesource.com/deps/inspector_protocol/",
             "externalRefs": [
                 {
@@ -5056,13 +8949,18 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "https://chromium.googlesource.com/deps/inspector_protocol/",
             "licenseConcluded": "BSD-3-Clause",
-            "name": "inspector protocol"
+            "licenseDeclared": "BSD-3-Clause",
+            "name": "inspector protocol",
+            "primaryPackagePurpose": "LIBRARY",
+            "versionInfo": "1b1bcbbe060e8c8cd8704f00f78978c50991b307"
         },
         {
             "SPDXID": "SPDXRef-Package-siphash",
-            "downloadLocation": "NONE",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -5070,14 +8968,19 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-v8-third-party-siphash-license"
-            ],
-            "name": "siphash"
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "LicenseRef-v8-third-party-siphash-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "siphash",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-DFA-UTF-8-Decoder",
+            "attributionTexts": [
+                "Security Critical: yes"
+            ],
+            "copyrightText": "NOASSERTION",
             "downloadLocation": "http://bjoern.hoehrmann.de/utf-8/decoder/dfa/",
             "externalRefs": [
                 {
@@ -5086,13 +8989,17 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
+            "filesAnalyzed": false,
+            "homepage": "http://bjoern.hoehrmann.de/utf-8/decoder/dfa/",
             "licenseConcluded": "MIT",
-            "name": "DFA UTF-8 Decoder"
+            "licenseDeclared": "MIT",
+            "name": "DFA UTF-8 Decoder",
+            "primaryPackagePurpose": "LIBRARY"
         },
         {
             "SPDXID": "SPDXRef-Package-v8",
-            "downloadLocation": "NONE",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "NOASSERTION",
             "externalRefs": [
                 {
                     "referenceCategory": "OTHER",
@@ -5105,1669 +9012,1674 @@
                     "referenceType": "url"
                 }
             ],
-            "filesAnalyzed": true,
-            "licenseInfoFromFiles": [
-                "LicenseRef-v8-third-party-v8-builtins-license",
-                "LicenseRef-v8-third-party-v8-codegen-license"
-            ],
-            "name": "v8"
+            "filesAnalyzed": false,
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "LicenseRef-v8-third-party-v8-builtins-license AND LicenseRef-v8-third-party-v8-codegen-license",
+            "licenseDeclared": "NOASSERTION",
+            "name": "v8",
+            "primaryPackagePurpose": "LIBRARY"
         }
     ],
     "relationships": [
         {
             "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-Chromium",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CityHash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CityHash-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Google-Double-Conversion",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Netscape-Portable-Runtime--NSPR-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Paul-Hsieh-s-SuperFastHash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-google-glog-s-symbolization-library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-xdg-user-dirs",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Mozilla-Personal-Security-Manager",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Mozilla-Windows-Cert-code",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-QUICHE",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-URI-Template-Parser",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Abseil",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Almost-Native-Graphics-Layer-Engine",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-xxHash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-NVidia-Control-X-Extension-Library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Volk-Meta-loader-for-Vulkan-API",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Anonymous-Tokens",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-AXE-CORE-Accessibility-Audit",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-WebKit",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-BoringSSL",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Fiat-Crypto--Synthesizing-Correct-by-Construction-Code-for-Cryptographic-Primitives",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Brotli",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Compact-Encoding-Detection",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Compact-Language-Detector-v3",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-compiler-rt",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Google-Chrome-Content-Analysis-Connector-Agent-SDK",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Core-ML-Tools",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-cpuinfo",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CrabbyAvif---Library-for-decoding-AVIF-files.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Crashpad",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-getopt",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Linux-Syscall-Support",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CRC32C",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-d3",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-dav1d-is-an-AV1-decoder---",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Dawn",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-EGL-Registry",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-DirectX-Shader-Compiler",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Blackmagic-DeckLink-SDK---Mac",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Devtools-Frontend",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Acorn--a-tiny--fast-JavaScript-parser-written-in-JavaScript.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CodeMirror-5",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CodeMirror-6",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-CSP-Evaluator-Core-Library--a-tool-that-allows-developers-to-check-if-a-Content-Security-Policy--CSP--serves-as-mitigation-against-XSS-attacks",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-The-Diff-Match-and-Patch-libraries-offer-robust-algorithms-to-perform-the-operations-required-for-synchronizing-plain-text.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lighthouse-i18n.js",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-intl-messageformat",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-json5",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-legacy-javascript",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lighthouse",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lit",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Marked",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Puppeteer-Core",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package--puppeteer-replay",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-mitt",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-parsel",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-rxjs",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-source-map-scopes-codec",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-third-party-web",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package--vscode-web-custom-data",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Wasmparser",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Web-Vitals",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-dom-distiller-js",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-dragonbox",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Emoji-Segmenter",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Expat-XML-Parser",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FarmHash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-fast-float",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-V8-fork-of-fdlibm",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-federated-compute",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ffmpeg",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-2-dim-General-Purpose-FFT--Fast-Fourier-Cosine-Sine-Transform--Package",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-flac",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FlatBuffers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-fontconfig",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FP16",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FreeType",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FXDiv",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-gemmlowp",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-harfbuzz",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Highway--C---library-for-SIMD",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-hunspell",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-IAccessible2-COM-interfaces-for-accessibility",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Ink",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Ink-Stroke-Modeler",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-inspector-protocol",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ipcz",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ISimpleDOM-COM-interfaces-for-accessibility",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jsoncpp",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lens-Protos",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-LevelDB--A-Fast-Persistent-Key-Value-Store",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libaddressinput",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Alliance-for-Open-Media-Video-Codec",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-FAST",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-vector",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libcxx",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libcxxabi",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libgav1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libjpeg-turbo",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-International-Phone-Number-Library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libsecret",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libsrtp",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Android-Explicit-Synchronization",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Libtess2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-URL-Pattern-Library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libusbx",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libvpx",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-WebM-container-parser-and-writer.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-WebP-image-encoder-decoder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libxml",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libxslt",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libyuv",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libzip",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lit-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-LiteRT",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-llvm-libc",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Lottie-Web",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-LZMA-SDK",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Material-color-utilities",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Metrics-Protos",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Headers-for-the-Windows-WebAuthn-API--webauthn.dll-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-minigbm",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-modp-base64-decoder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ARM-NEON-2-x86-SSE",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
-            "relatedSpdxElement": "SPDXRef-Package-Lit-1-1",
-            "relationshipType": "DESCRIBES"
+            "spdxElementId": "SPDXRef-Package-Chromium",
+            "relatedSpdxElement": "SPDXRef-Package-Lit-2",
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Mediapipe-Tasks-Vision",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Microsoft-Authentication-Library-for-JavaScript--MSAL.js--for-Browser-Based-Single-Page-Applications",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package--bufbuild-protobuf",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-messageformat",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-oak",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Omnibox-Protos",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-One-Euro-Filter",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-OpenH264",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Open-Screen-Protocol-Library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-BoringSSL-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jsoncpp-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-OpenXR-SDK",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-JNIPP",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-android-jni-wrappers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-opus",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-OTS--OpenType-Sanitizer-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-PDFium",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Anti-Grain-Geometry",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-C---Big-Integer-Library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-OpenJPEG",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-LibTIFF",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Perfetto",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-PFFFT--a-pretty-fast-FFT.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Polymer",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Private-Join-and-Compute-subset",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-PSM--Private-Set-Membership--client-side",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Protocol-Buffers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Protocol-Buffers--javascript-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-utf8-range",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-pthreadpool",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Puffin-deterministic-deflate-recompressor",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-re2---an-efficient--principled-regular-expression-library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Recurrent-neural-network-for-audio-noise-reduction",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-adler2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-anyhow",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-array-init",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-arrayvec",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-bitflags",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-bitflags-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-bytemuck",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-bytemuck-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-byteorder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-byteorder-lite",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-calendrical-calculations",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-cfg-if",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-codespan-reporting",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-core-maths",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-crc32fast",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-cxx",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-cxxbridge-macro",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-derivre",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-diplomat",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-diplomat-core",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-diplomat-runtime",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-displaydoc",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-either",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-encoding-rs",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-equivalent",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-fdeflate",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-flate2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-foldhash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-font-types",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-hashbrown",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-hashbrown-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-heck",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-hmac-sha256",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-calendar",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-calendar-data",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-collections",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-locale",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-locale-core",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-locale-data",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-icu-provider",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-image",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-indexmap",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-itoa",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ixdtf",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jxl",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jxl-macros",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jxl-simd",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-jxl-transforms",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-lazy-static",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libc",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libm",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-litemap",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-llguidance",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-log",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-memchr",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-miniz-oxide",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-moxcms",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-num-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-num-traits",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-png",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-potential-utf",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-proc-macro2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-proc-macro-error2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-proc-macro-error-attr2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-pxfm",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-qr-code",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-quote",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-read-fonts",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-regex-syntax",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-resb",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-rustversion",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-ryu",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-serde",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-serde-core",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-serde-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-serde-json",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-serde-json-lenient",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-simd-adler32",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-skrifa",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-smallvec",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-stable-deref-trait",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-strck",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-strum",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-strum-macros",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-bundle-flac",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-bundle-mp3",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-codec-pcm",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-codec-vorbis",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-core",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-metadata",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-symphonia-utils-xiph",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-syn",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-synstructure",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-temporal-capi",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-temporal-rs",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-termcolor",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-thiserror",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-thiserror-impl",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-timezone-provider",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-tinystr",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-toktrie",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-typed-path",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-unicode-ident",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-unicode-width",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-utf8-iter",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-winapi-util",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-windows-sys",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-windows-targets",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-windows-x86-64-msvc",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-writeable",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-xml",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-yoke",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-yoke-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zerofrom",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zerofrom-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zerotrie",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zerovec",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zerovec-derive",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zip",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zmij",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zoneinfo64",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-The-ruy-matrix-multiplication-library",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Search-Engines-resources",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Sentencepiece",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Simple-Homomorphic-Encryption-Library-with-Lattices",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-simdutf-unicode-transcoder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Skia",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SMHasher",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Snappy--A-fast-compressor-decompressor",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Speech-Dispatcher",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SPIR-V-Headers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SPIR-V-Tools",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-sqlite",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SwiftShader",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SPIRV-Headers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-SPIRV-Tools",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-The-Arm-ASTC-Encoder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-LLVM",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-llvm-subzero",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Marl",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Subzero",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-TensorFlow-Text",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-TensorFlow-Models",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-TensorFlow-Lite",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Accelerated-Linear-Algebra",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-TensorFlow-Lite-Support",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-UnRAR-source-for-decompressing-.RAR-and-other-files.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-libutf",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Vulkan-API-headers",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Vulkan-Loader-Components",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-VulkanMemoryAllocator",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-WebRTC",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-General-Purpose-FFT--Fast-Fourier-Cosine-Sine-Transform--Package",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-spl-sqrt-floor",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-fft",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-g711",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-g722",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-woff2",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Windows-Template-Library--WTL-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Wuffs--Wrangling-Untrusted-File-Formats-Safely-",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-XNNPACK",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-zlib",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-Zstandard",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-C---port-of-zxcvbn--an-advanced-password-strength-estimation-library.",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-url-parse",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-V8-JavaScript-Engine",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-glibc",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-inspector-protocol-1",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-siphash",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-DFA-UTF-8-Decoder",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         },
         {
-            "spdxElementId": "SPDXRef-DOCUMENT",
+            "spdxElementId": "SPDXRef-Package-Chromium",
             "relatedSpdxElement": "SPDXRef-Package-v8",
-            "relationshipType": "DESCRIBES"
+            "relationshipType": "CONTAINS"
         }
     ]
 }


### PR DESCRIPTION
This changeset updates the generated SPDX document.

The updated SPDX output is stricter and carries more package-level metadata from Chromium's third-party license metadata:

- Uses valid package-level SPDX fields for packages without file entries: `filesAnalyzed: false`, package-level `licenseConcluded`, `licenseDeclared` where available, `copyrightText: NOASSERTION`, and required package metadata.
- Represents Chromium as the root SPDX package and connects shipped third-party packages with `CONTAINS` relationships.
- Moves package URLs into `homepage` / `downloadLocation`, emits package-manager identifiers as `PACKAGE_MANAGER/purl` external refs, and keeps the license file link as an `OTHER/url` external ref.
- Adds upstream metadata where available: versions, upstream revision hashes, security-critical attribution text, PURL refs, and CPE security refs.
- Uses SPDX-compliant `NOASSERTION` values for unknown URLs and emits the document creation timestamp in UTC.

Current generated package metadata coverage:

| Package metadata | Packages | % of packages |
|---|---:|---:|
| Security critical (`yes`) | 264 | 79.8% |
| Version info | 279 | 84.3% |
| Source info (upstream commit hash) | 181 | 54.7% |
| CPE security refs | 39 | 11.8% |
| PURL refs | 251 | 75.8% |
| `licenseConcluded`: standard SPDX expression | 305 | 92.1% |
| `licenseConcluded`: `LicenseRef-*` fallback | 26 | 7.9% |
| `licenseConcluded`: total | 331 | 100.0% |

Compared with the previous SPDX file, all 331 third-party packages now have a package-level `licenseConcluded`. The 305 packages with standard SPDX conclusions also include `licenseDeclared`; the remaining 26 packages keep explicit `LicenseRef-*` conclusions when Chromium metadata does not map cleanly to a standard SPDX expression.

CPE and PURL refs are intentionally emitted only when Chromium metadata provides reliable identifiers. They remain absent for packages whose source URLs point to hosts or formats that do not map reliably to typed package identifiers, such as Google Gitiles/Gerrit, self-hosted GitLab/cgit/hg, project home pages, or free-text URLs.
